### PR TITLE
GBR interleavesound update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,2 @@
-This repository contains an archive of requested non-standard Special Time (ST)
-and Discretionary Time (DT) radar control programs. Please contact the radar
-control program author or experiment requester with any questions.
+This repository contains an archive of SuperDARN radar control programs.
+Please contact the control program author or experiment requester with any questions.

--- a/qnx4/interleavesound.1.00/interleavesound.c
+++ b/qnx4/interleavesound.1.00/interleavesound.c
@@ -45,6 +45,10 @@
 
 /*
  $Log: interleavesound.c,v $
+ Revision 1.1  2021/09/15 egthomas
+ Modification to set number of ranges used for frequency
+ sounding independently of nrang for the interleaved scan
+
  Revision 1.0  2019/06/14 egthomas
  Initial revision from interleavedscan and normalsound
  
@@ -57,7 +61,7 @@
 #define TASK_NAMES "echo_data","iqwrite","rawacfwrite","fitacfwrite"
 
 char cmdlne[1024];
-char progid[80]={"$Id: interleavesound.c,v 1.0 2019/06/14 egthomas Exp $"};
+char progid[80]={"$Id: interleavesound.c,v 1.1 2021/09/15 egthomas Exp $"};
 char progname[256];
 struct TaskID *errlog;
 

--- a/qnx4/interleavesound.1.00/interleavesound.c
+++ b/qnx4/interleavesound.1.00/interleavesound.c
@@ -177,20 +177,22 @@ int main(int argc,char *argv[]) {
   int snd_freq;
   int snd_frqrng=100;
   float snd_time, snd_intt, time_needed=1.25;
+  int snd_bms_tot, snd_intt_sc, snd_intt_us;
+  int fast_intt_sc, fast_intt_us;
   unsigned char limit_fswitch=0;
 
   if (num_scans == 16) {
-    int snd_bms_tot=8;
-    int fast_intt_sc=3;
-    int fast_intt_us=0;
-    int snd_intt_sc=2;
-    int snd_intt_us=0;
-  else if (num_scans == 20) {
-    int snd_bms_tot=10;
-    int fast_intt_sc=2;
-    int fast_intt_us=400000;
-    int snd_intt_sc=1;
-    int snd_intt_us=500000;
+    snd_bms_tot=8;
+    fast_intt_sc=3;
+    fast_intt_us=0;
+    snd_intt_sc=2;
+    snd_intt_us=0;
+  } else if (num_scans == 20) {
+    snd_bms_tot=10;
+    fast_intt_sc=2;
+    fast_intt_us=400000;
+    snd_intt_sc=1;
+    snd_intt_us=500000;
   }
 
   snd_intt = snd_intt_sc + snd_intt_us*1e-6;

--- a/qnx4/interleavesound.1.00/interleavesound.c
+++ b/qnx4/interleavesound.1.00/interleavesound.c
@@ -531,7 +531,7 @@ int main(int argc,char *argv[]) {
         if (exitpoll !=0) break;
 
         if (limit_fswitch) {
-          /* check for the end of a frequency loop */
+          /* check for the end of a frequency loop (optional) */
           snd_bm_cnt++;
           if (snd_bm_cnt >= snd_bms_tot) {
             /* reset the beam counter and increment the freq counter */

--- a/qnx4/interleavesound.1.00/interleavesound.c
+++ b/qnx4/interleavesound.1.00/interleavesound.c
@@ -505,7 +505,7 @@ int main(int argc,char *argv[]) {
         /* Only send these to echo_data; otherwise they get written to the data files */
         RMsgSndSend(tlist[0], &msg);
 
-        sprintf(logtxt, "SBC: %d  SFC: %d\n", snd_bm_cnt, snd_freq_cnt);
+        sprintf(logtxt, "SBC: %d  SFC: %d", snd_bm_cnt, snd_freq_cnt);
         ErrLog(errlog, progname, logtxt);
 
         /* set the scan variable for the sounding mode data file only */
@@ -518,7 +518,7 @@ int main(int argc,char *argv[]) {
         /* save the sounding mode data */
         write_snd_record(progname, &prm, &fit);
 
-        ErrLog(errlog, progname, "Polling SND for exit.");
+        ErrLog(errlog, progname, "Polling SND for exit.\n");
         exitpoll=RadarShell(sid,&rstable);
         if (exitpoll !=0) break;
 

--- a/qnx4/interleavesound.1.00/interleavesound.c
+++ b/qnx4/interleavesound.1.00/interleavesound.c
@@ -120,6 +120,8 @@ int main(int argc,char *argv[]) {
   int skip;
   int cnt=0;
 
+  int def_nrang=75;
+
   unsigned char discretion=0;
 
   /* ---------- Beam sequence for interleavedscan ---------- */
@@ -176,6 +178,7 @@ int main(int argc,char *argv[]) {
   int odd_beams=0;
   int snd_freq;
   int snd_frqrng=100;
+  int snd_nrang=75;
   float snd_time, snd_intt, time_needed=1.25;
   unsigned char limit_fswitch=0;
 
@@ -239,7 +242,7 @@ int main(int argc,char *argv[]) {
   mplgs  = 23;
   mpinc  = 1500;
   dmpinc = 1500;
-  nrang  = 75;
+  nrang  = def_nrang;
   rsep   = 45;
   txpl   = 300; /* recalculated below with rsep */
   frang  = 180;
@@ -284,6 +287,8 @@ int main(int argc,char *argv[]) {
   OpsLogStart(errlog,progname,argc,argv);
 
   SiteSetupHardware();
+
+  def_nrang = nrang;
 
   // set a negative CPID for discretionary time
   if (discretion) cp = -cp;
@@ -444,6 +449,7 @@ int main(int argc,char *argv[]) {
       while (snd_time-snd_intt > time_needed) {
         intsc = snd_intt_sc;
         intus = snd_intt_us;
+        nrang = snd_nrang;
 
         /* set the beam */
         bmnum = snd_bms[snd_bm_cnt] + odd_beams;
@@ -548,6 +554,7 @@ int main(int argc,char *argv[]) {
       /* now wait for the next interleavescan */
       intsc = fast_intt_sc;
       intus = fast_intt_us;
+      nrang = def_nrang;
       OpsWaitBoundary(scnsc,scnus);
     }
 

--- a/qnx4/interleavesound.1.00/interleavesound.c
+++ b/qnx4/interleavesound.1.00/interleavesound.c
@@ -472,6 +472,8 @@ int main(int argc,char *argv[]) {
         SiteSetBeam(bmnum);
 
         ErrLog(errlog, progname, "Doing SND clear frequency search.");
+        sprintf(logtxt,"FRQ: %d %d",snd_freq,snd_frqrng);
+        ErrLog(errlog,progname,logtxt);
         if (SiteFCLR(snd_freq, snd_freq + snd_frqrng)==FREQ_LOCAL)
           ErrLog(errlog,progname,"Frequency Synthesizer in local mode.");
         SiteSetFreq(tfreq);

--- a/qnx4/interleavesound.1.00/interleavesound.c
+++ b/qnx4/interleavesound.1.00/interleavesound.c
@@ -236,20 +236,20 @@ int main(int argc,char *argv[]) {
                   &dmpinc,&nmpinc,
                   &frqrng,&xcnt);
 
+  SiteStart();
+
   // For 1-min normal scan
   cp     = 197;
   intsc  = fast_intt_sc;
   intus  = fast_intt_us;
   mppul  = 8;
   mplgs  = 23;
-  mpinc  = 1500;
   dmpinc = 1500;
+  nmpinc = 1500;
   nrang  = 75;
   rsep   = 45;
   txpl   = 300; /* recalculated below with rsep */
   frang  = 180;
-
-  SiteStart();
 
 #if 1
   //maxatten=1;	//Chris

--- a/qnx4/interleavesound.1.00/interleavesound.c
+++ b/qnx4/interleavesound.1.00/interleavesound.c
@@ -180,20 +180,22 @@ int main(int argc,char *argv[]) {
   int snd_frqrng=100;
   int snd_nrang=75;
   float snd_time, snd_intt, time_needed=1.25;
+  int snd_bms_tot, snd_intt_sc, snd_intt_us;
+  int fast_intt_sc, fast_intt_us;
   unsigned char limit_fswitch=0;
 
   if (num_scans == 16) {
-    int snd_bms_tot=8;
-    int fast_intt_sc=3;
-    int fast_intt_us=0;
-    int snd_intt_sc=2;
-    int snd_intt_us=0;
+    snd_bms_tot=8;
+    fast_intt_sc=3;
+    fast_intt_us=0;
+    snd_intt_sc=2;
+    snd_intt_us=0;
   } else if (num_scans == 20) {
-    int snd_bms_tot=10;
-    int fast_intt_sc=2;
-    int fast_intt_us=400000;
-    int snd_intt_sc=1;
-    int snd_intt_us=500000;
+    snd_bms_tot=10;
+    fast_intt_sc=2;
+    fast_intt_us=400000;
+    snd_intt_sc=1;
+    snd_intt_us=500000;
   }
 
   snd_intt = snd_intt_sc + snd_intt_us*1e-6;

--- a/qnx4/interleavesound.1.00/interleavesound.c
+++ b/qnx4/interleavesound.1.00/interleavesound.c
@@ -188,7 +188,7 @@ int main(int argc,char *argv[]) {
   else if (num_scans == 20) {
     int snd_bms_tot=10;
     int fast_intt_sc=2;
-    int fast_intt_us=500000;
+    int fast_intt_us=400000;
     int snd_intt_sc=1;
     int snd_intt_us=500000;
   }

--- a/qnx4/interleavesound.1.00/interleavesound.c
+++ b/qnx4/interleavesound.1.00/interleavesound.c
@@ -188,7 +188,7 @@ int main(int argc,char *argv[]) {
     int fast_intt_us=0;
     int snd_intt_sc=2;
     int snd_intt_us=0;
-  else if (num_scans == 20) {
+  } else if (num_scans == 20) {
     int snd_bms_tot=10;
     int fast_intt_sc=2;
     int fast_intt_us=400000;

--- a/qnx4/interleavesound.1.00/version.info
+++ b/qnx4/interleavesound.1.00/version.info
@@ -1,9 +1,13 @@
 # $Log: version.info,v $
 #
+# Revision 1.1  2021/09/15 egthomas
+# Modification to set number of ranges used for frequency
+# sounding independently of nrang for the interleaved scan
+#
 # Revision 1.0  2019/06/14 egthomas
 # Initial revision from interleavedscan and normalsound
 #
 #
-interleavesound.c 1.00
+interleavesound.c 1.01
 sndwrite.c 1.01
 sndwrite.h 1.00

--- a/qnx4/interleavesound_stereo.1.00/interleavesound_stereo.c
+++ b/qnx4/interleavesound_stereo.1.00/interleavesound_stereo.c
@@ -1007,6 +1007,8 @@ void write_snd_record(char *progname, struct RadarParm *prm, struct FitData *fit
   status = SndFwrite(out, prm, fit);
   if (status == -1) {
     ErrLog(errlog,progname,"Error writing sounding record.");
+  } else {
+    ErrLog(errlog,progname,"Sounding record succesfully written.");
   }
 
   fclose(out);

--- a/qnx4/normalsound.3.00/normalsound.c
+++ b/qnx4/normalsound.3.00/normalsound.c
@@ -194,21 +194,23 @@ int main(int argc,char *argv[]) {
   int snd_frqrng=100;
   int snd_nrang=75;
   float snd_time, snd_intt, time_needed=1.25;
+  int snd_bms_tot, snd_intt_sc, snd_intt_us;
+  int fast_intt_sc, fast_intt_us;
 
   if (snd_bms_tot == 8) {
-    int normal_intt_sc=6;
-    int normal_intt_us=0;
-    int fast_intt_sc=3;
-    int fast_intt_us=0;
-    int snd_intt_sc=2;
-    int snd_intt_us=0;
-  else if (snd_bms_tot == 10) {
-    int normal_intt_sc=5;
-    int normal_intt_us=0;
-    int fast_intt_sc=2;
-    int fast_intt_us=400000;
-    int snd_intt_sc=1;
-    int snd_intt_us=500000;
+    normal_intt_sc=6;
+    normal_intt_us=0;
+    fast_intt_sc=3;
+    fast_intt_us=0;
+    snd_intt_sc=2;
+    snd_intt_us=0;
+  } else if (snd_bms_tot == 10) {
+    normal_intt_sc=5;
+    normal_intt_us=0;
+    fast_intt_sc=2;
+    fast_intt_us=400000;
+    snd_intt_sc=1;
+    snd_intt_us=500000;
   }
 
   snd_intt = snd_intt_sc + snd_intt_us*1e-6;

--- a/qnx4/normalsound.3.00/normalsound.c
+++ b/qnx4/normalsound.3.00/normalsound.c
@@ -46,8 +46,9 @@
 
 /*
  $Log: normalsound.c,v $
- Revision 3.0  2020/09/25 egthomas
- Modification to use dmap sounding file format
+ Revision 3.0  2021/09/15 egthomas
+ Modification to use dmap sounding file format and
+ independent number of ranges for frequency sounding
 
  Revision 2.7  2008/03/15 00:47:25  code
  Added iqwrite.
@@ -82,7 +83,7 @@
 #define TASK_NAMES "echo_data","iqwrite","rawacfwrite","fitacfwrite"
 
 char cmdlne[1024];
-char progid[80]={"$Id: normalsound.c,v 3.0 2020/09/25 egthomas Exp $"};
+char progid[80]={"$Id: normalsound.c,v 3.0 2021/09/15 egthomas Exp $"};
 char progname[256];
 struct TaskID *errlog;
 
@@ -197,6 +198,7 @@ int main(int argc,char *argv[]) {
   int normal_intt_sc, normal_intt_us;
   int fast_intt_sc, fast_intt_us;
   int snd_intt_sc, snd_intt_us;
+  unsigned char limit_fswitch=0;
 
   if (snd_bms_tot == 8) {
     normal_intt_sc=6;
@@ -291,6 +293,9 @@ int main(int argc,char *argv[]) {
   OptionAdd(&opt, "fast", 'x', &fast);
   OptionAdd(&opt, "frqrng", 'i', &frqrng);
   OptionAdd(&opt, "sfrqrng", 'i',&snd_frqrng); /* sounding FCLR window [kHz] */
+  OptionAdd(&opt, "lf", 'x', &limit_fswitch);  /* limit amount of frequency switching
+                                                  by iterating over all sounding beams
+                                                  before proceeding to next frequency */
 
   arg=OptionProcess(1,argc,argv,&opt,NULL);
 
@@ -538,15 +543,29 @@ int main(int argc,char *argv[]) {
         exitpoll=RadarShell(sid,&rstable);
         if (exitpoll !=0) break;
 
-        /* check for the end of a beam loop */
-        snd_freq_cnt++;
-        if (snd_freq_cnt >= snd_freqs_tot) {
-          /* reset the freq counter and increment the beam counter */
-          snd_freq_cnt = 0;
+        if (limit_fswitch) {
+          /* check for the end of a frequency loop (optional) */
           snd_bm_cnt++;
           if (snd_bm_cnt >= snd_bms_tot) {
+            /* reset the beam counter and increment the freq counter */
             snd_bm_cnt = 0;
             odd_beams = !odd_beams;
+            if (!odd_beams) snd_freq_cnt++;
+            if (snd_freq_cnt >= snd_freqs_tot) {
+              snd_freq_cnt = 0;
+            }
+          }
+        } else {
+          /* check for the end of a beam loop (default) */
+          snd_freq_cnt++;
+          if (snd_freq_cnt >= snd_freqs_tot) {
+            /* reset the freq counter and increment the beam counter */
+            snd_freq_cnt = 0;
+            snd_bm_cnt++;
+            if (snd_bm_cnt >= snd_bms_tot) {
+              snd_bm_cnt = 0;
+              odd_beams = !odd_beams;
+            }
           }
         }
 

--- a/qnx4/normalsound.3.00/normalsound.c
+++ b/qnx4/normalsound.3.00/normalsound.c
@@ -203,7 +203,7 @@ int main(int argc,char *argv[]) {
     int normal_intt_sc=5;
     int normal_intt_us=0;
     int fast_intt_sc=2;
-    int fast_intt_us=500000;
+    int fast_intt_us=400000;
     int snd_intt_sc=1;
     int snd_intt_us=500000;
   }

--- a/qnx4/normalsound.3.00/normalsound.c
+++ b/qnx4/normalsound.3.00/normalsound.c
@@ -194,7 +194,7 @@ int main(int argc,char *argv[]) {
   int snd_frqrng=100;
   int snd_nrang=75;
   float snd_time, snd_intt, time_needed=1.25;
-  int snd_bms_tot, snd_intt_sc, snd_intt_us;
+  int snd_intt_sc, snd_intt_us;
   int fast_intt_sc, fast_intt_us;
 
   if (snd_bms_tot == 8) {

--- a/qnx4/normalsound.3.00/normalsound.c
+++ b/qnx4/normalsound.3.00/normalsound.c
@@ -480,6 +480,8 @@ int main(int argc,char *argv[]) {
         SiteSetBeam(bmnum);
 
         ErrLog(errlog, progname, "Doing SND clear frequency search.");
+        sprintf(logtxt,"FRQ: %d %d",snd_freq,snd_frqrng);
+        ErrLog(errlog,progname,logtxt);
         if (SiteFCLR(snd_freq, snd_freq + snd_frqrng)==FREQ_LOCAL)
           ErrLog(errlog,progname,"Frequency Synthesizer in local mode.");
         SiteSetFreq(tfreq);

--- a/qnx4/normalsound.3.00/normalsound.c
+++ b/qnx4/normalsound.3.00/normalsound.c
@@ -191,21 +191,24 @@ int main(int argc,char *argv[]) {
   int snd_freq;
   int snd_frqrng=100;
   float snd_time, snd_intt, time_needed=1.25;
+  int normal_intt_sc, normal_intt_us;
+  int fast_intt_sc, fast_intt_us;
+  int snd_intt_sc, snd_intt_us;
 
   if (snd_bms_tot == 8) {
-    int normal_intt_sc=6;
-    int normal_intt_us=0;
-    int fast_intt_sc=3;
-    int fast_intt_us=0;
-    int snd_intt_sc=2;
-    int snd_intt_us=0;
-  else if (snd_bms_tot == 10) {
-    int normal_intt_sc=5;
-    int normal_intt_us=0;
-    int fast_intt_sc=2;
-    int fast_intt_us=400000;
-    int snd_intt_sc=1;
-    int snd_intt_us=500000;
+    normal_intt_sc=6;
+    normal_intt_us=0;
+    fast_intt_sc=3;
+    fast_intt_us=0;
+    snd_intt_sc=2;
+    snd_intt_us=0;
+  } else if (snd_bms_tot == 10) {
+    normal_intt_sc=5;
+    normal_intt_us=0;
+    fast_intt_sc=2;
+    fast_intt_us=400000;
+    snd_intt_sc=1;
+    snd_intt_us=500000;
   }
 
   snd_intt = snd_intt_sc + snd_intt_us*1e-6;

--- a/qnx4/normalsound.3.00/normalsound.c
+++ b/qnx4/normalsound.3.00/normalsound.c
@@ -516,7 +516,7 @@ int main(int argc,char *argv[]) {
         /* Only send these to echo_data; otherwise they get written to the data files */
         RMsgSndSend(tlist[0], &msg);
 
-        sprintf(logtxt, "SBC: %d  SFC: %d\n", snd_bm_cnt, snd_freq_cnt);
+        sprintf(logtxt, "SBC: %d  SFC: %d", snd_bm_cnt, snd_freq_cnt);
         ErrLog(errlog, progname, logtxt);
 
         /* set the scan variable for the sounding mode data file only */
@@ -529,7 +529,7 @@ int main(int argc,char *argv[]) {
         /* save the sounding mode data */
         write_snd_record(progname, &prm, &fit);
 
-        ErrLog(errlog, progname, "Polling SND for exit.");
+        ErrLog(errlog, progname, "Polling SND for exit.\n");
         exitpoll=RadarShell(sid,&rstable);
         if (exitpoll !=0) break;
 

--- a/qnx4/normalsound.3.00/normalsound.c
+++ b/qnx4/normalsound.3.00/normalsound.c
@@ -194,8 +194,9 @@ int main(int argc,char *argv[]) {
   int snd_frqrng=100;
   int snd_nrang=75;
   float snd_time, snd_intt, time_needed=1.25;
-  int snd_intt_sc, snd_intt_us;
+  int normal_intt_sc, normal_intt_us;
   int fast_intt_sc, fast_intt_us;
+  int snd_intt_sc, snd_intt_us;
 
   if (snd_bms_tot == 8) {
     normal_intt_sc=6;

--- a/qnx4/normalsound.3.00/normalsound.c
+++ b/qnx4/normalsound.3.00/normalsound.c
@@ -145,6 +145,8 @@ int main(int argc,char *argv[]) {
   int skip;
   int cnt=0;
 
+  int def_nrang=75;
+
   unsigned char fast=0;
   unsigned char discretion=0;
 
@@ -190,6 +192,7 @@ int main(int argc,char *argv[]) {
   int odd_beams=0;
   int snd_freq;
   int snd_frqrng=100;
+  int snd_nrang=75;
   float snd_time, snd_intt, time_needed=1.25;
 
   if (snd_bms_tot == 8) {
@@ -253,7 +256,7 @@ int main(int argc,char *argv[]) {
   mplgs  = 23;
   mpinc  = 1500;
   dmpinc = 1500;
-  nrang  = 75;
+  nrang  = def_nrang;
   rsep   = 45;
   txpl   = 300; /* recalculated below with rsep */
   frang  = 180;
@@ -305,6 +308,9 @@ int main(int argc,char *argv[]) {
     intsc = fast_intt_sc;
     intus = fast_intt_us;
   }
+
+  def_nrang = nrang;
+
   if (discretion) cp = -cp;
 
   // recalculate txpl
@@ -454,6 +460,7 @@ int main(int argc,char *argv[]) {
       while (snd_time-snd_intt > time_needed) {
         intsc = snd_intt_sc;
         intus = snd_intt_us;
+        nrang = snd_nrang;
 
         /* set the beam */
         bmnum = snd_bms[snd_bm_cnt] + odd_beams;
@@ -549,6 +556,7 @@ int main(int argc,char *argv[]) {
         intsc = normal_intt_sc;
         intus = normal_intt_us;
       }
+      nrang = def_nrang;
       OpsWaitBoundary(scnsc,scnus);
     }
 

--- a/qnx4/normalsound.3.00/normalsound.c
+++ b/qnx4/normalsound.3.00/normalsound.c
@@ -252,19 +252,19 @@ int main(int argc,char *argv[]) {
                   &dmpinc,&nmpinc,
                   &frqrng,&xcnt);
 
+  SiteStart();
+
   cp     = 155;
   intsc  = normal_intt_sc;
   intus  = normal_intt_us;
   mppul  = 8;
   mplgs  = 23;
-  mpinc  = 1500;
   dmpinc = 1500;
+  nmpinc = 1500;
   nrang  = 75;
   rsep   = 45;
   txpl   = 300; /* recalculated below with rsep */
   frang  = 180;
-
-  SiteStart();
 
 #if 1
   //maxatten=1;	//Chris

--- a/qnx4/normalsound.3.00/version.info
+++ b/qnx4/normalsound.3.00/version.info
@@ -1,7 +1,8 @@
 # $Log: version.info,v $
 #
-# Revision 3.0  2020/09/25 egthomas
-# Modification to use dmap sounding file format
+# Revision 3.0  2021/09/15 egthomas
+# Modification to use dmap sounding file format and
+# independent number of ranges for frequency sounding
 #
 #Revision 2.7  2008/03/15 00:47:44  code
 #Added iqwrite.

--- a/qnx4/sd_leicester/han/nailedscan/makefile
+++ b/qnx4/sd_leicester/han/nailedscan/makefile
@@ -1,0 +1,55 @@
+# Makefile for nailedscan
+# =======================
+# by R.J.Barnes
+#
+#
+
+
+INCLUDE=-I$(IPATH)/base -I$(IPATH)/general -I$(IPATH)/superdarn \
+	-I$(IPATH)/radarqnx4 \
+	-I$(USR_IPATH)/radarqnx4/ops \
+	-I$(USR_IPATH)/radarqnx4/site.$(SD_RADARCODE)
+
+OBJS = nailedscan.o
+SRC=nailedscan.c
+IGNVER=1
+OUTPUT = $(USR_BINPATH)/nailedscan
+SUDO = 1 
+LIBS=-lsite.${SD_RADARCODE}.1 -lops.1 -lfitacf.1 -lradar.1 -lerrlog.1 \
+     -lrs.1 -lfreq.1 -lacf.1 -ltcpipmsg.1 -lrawfeed.1 -ltsg.1  \
+     -ltaskid.1 -lrmsgsnd.1 -lrtimer.1 -lrtime.1 -lrmath.1 -lopt.1 
+
+include $(SITELIB).${SD_RADARCODE}
+
+ifdef STEREO
+include $(MAKEBIN)
+else
+version: version.info $(SRC)
+	$(BINPATH)/rcsv -t version.info
+clean:
+	rm -f *.o
+	rm -f $(OUTPUT)
+endif
+
+
+
+
+
+
+
+  
+
+
+
+
+
+
+
+
+
+  
+
+
+ 
+
+

--- a/qnx4/sd_leicester/han/nailedscan/nailedscan.c
+++ b/qnx4/sd_leicester/han/nailedscan/nailedscan.c
@@ -1,0 +1,1281 @@
+/* nailedscan.c
+   ============
+
+   Modified stereoscan to run channel B at a fixed frequency
+
+   Author: R.J.Barnes
+*/
+#define NAILEDFREQ 11210
+/* this is the fixed frequency for channel B. It is not allowed as a
+   command line argument to prevent errors in entering the frequency */
+
+
+/*
+ Copyright 2004 The Johns Hopkins University/Applied Physics Laboratory.
+ All rights reserved.
+ 
+ This material may be used, modified, or reproduced by or for the U.S.
+ Government pursuant to the license rights granted under the clauses at DFARS
+ 252.227-7013/7014.
+ 
+ For any other permissions, please contact the Space Department
+ Program Office at JHU/APL.
+ 
+ This Distribution and Disclaimer Statement must be included in all copies of
+ "Radar Operating System - Control Programs" (hereinafter "the Program").
+ 
+ The Program was developed at The Johns Hopkins University/Applied Physics
+ Laboratory (JHU/APL) which is the author thereof under the "work made for
+ hire" provisions of the copyright law.  
+ 
+ JHU/APL assumes no obligation to provide support of any kind with regard to
+ the Program.  This includes no obligation to provide assistance in using the
+ Program or to provide updated versions of the Program.
+ 
+ THE PROGRAM AND ITS DOCUMENTATION ARE PROVIDED AS IS AND WITHOUT ANY EXPRESS
+ OR IMPLIED WARRANTIES WHATSOEVER.  ALL WARRANTIES INCLUDING, BUT NOT LIMITED
+ TO, PERFORMANCE, MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE ARE
+ HEREBY DISCLAIMED.  YOU ASSUME THE ENTIRE RISK AND LIABILITY OF USING THE
+ PROGRAM TO INCLUDE USE IN COMPLIANCE WITH ANY THIRD PARTY RIGHTS.  YOU ARE
+ ADVISED TO TEST THE PROGRAM THOROUGHLY BEFORE RELYING ON IT.  IN NO EVENT
+ SHALL JHU/APL BE LIABLE FOR ANY DAMAGES WHATSOEVER, INCLUDING, WITHOUT
+ LIMITATION, ANY LOST PROFITS, LOST SAVINGS OR OTHER INCIDENTAL OR
+ CONSEQUENTIAL DAMAGES, ARISING OUT OF THE USE OR INABILITY TO USE THE
+ PROGRAM."
+ 
+ 
+ 
+ 
+ 
+  
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/types.h>
+#include <sys/proxy.h>
+#include <sys/kernel.h>
+#include <string.h>
+#include <time.h>
+#include "rtypes.h"
+#include "option.h"
+#include "rtime.h"
+#include "limit.h"
+#include "radar.h"
+#include "rprm.h"
+#include "rawdata.h"
+#include "fitblk.h"
+#include "fitdata.h"
+#include "fitacf.h"
+
+#include "taskid.h"
+#include "errlog.h"
+#include "freq.h"
+#include "rmsg.h"
+#include "radarshell.h"
+#include "rmsgsnd.h"
+#include "tsg.h"
+#include "tsgtable.h"
+#include "maketsg.h"
+#include "global.h"
+#include "globals.h"
+#include "setup.h"
+#include "reopen.h"
+#include "tmseq.h"
+#include "raws.h"
+#include "sync.h"
+#include "interface.h"
+#include "hdw.h"
+
+/*
+ $Log: nailedscan.c,v $
+ Revision 1.4  2007/08/09 14:09:51  code
+ Allowed command lines to be passed as a file.
+
+ Revision 1.3  2007/08/08 16:55:44  code
+ Fixed bug in using hex notation for stid.
+
+ Revision 1.2  2006/07/12 15:51:43  code
+ Added call to set up command line and limited data written to rawacf and fitacf.
+
+ Revision 1.1  2006/03/30 11:19:18  barnes
+ Initial revision
+ 
+*/
+
+/*
+	Modified 10/12/2001 PH
+
+	Added bnA and bnB frequency band options to cycle through frequency
+	bands during each scan. No check is made for invalid band numbers.
+	A band number of -1 is ignored. Bands can be added/removed at any
+	time using radar_shell, changes won't take effect until the end of
+	the current scan. If no band numbers are specified, normal day/night
+	frequencies are used.
+
+	Frequency bands can also be specified for campA and campB modes.
+
+	Extra options can be placed in a separate schedule file. The file
+	name should be the last argument in the schedule argument list and
+	should include the full path.
+
+	Modified 16/01/02 PH
+
+	Fixed synchronisation bug. The code wasn't subtracting the time taken
+	for a clear frequency search from the beam integration time, resulting
+	in an extended beam dwell time and a sweep lasting for more than 60 s
+	for fast stereo and 120 s for slow stereo 7 s integration.
+
+	Standard slow stereo (normal stereo) is now 7 seconds (by Mark Lester).
+
+	Modified 30/01/02 PH
+
+	added -cts? options that pre-set other options
+
+			dwell	chan A	cpidA	chan B	cpidB	Ice/Fin	offset	range
+			------	------	------	------	------	------- ------	-----
+	cts2 -    7		normal	 152	 tbj	-26002	 5 / 9	 +400	 45
+	cts4 -	  7		normal	 152	normal	-26004	 5 / 9	 +400	 45
+	cts6 -	  7		normal	 152	1 camp	-26006	 5 / 9	 +400	 45
+	cts8 -	  7		normal	 152	2 camp	-26008	 5 / 9	 +400	 45
+
+	cts3 -	  3		normal	 153	 tbj	-26003	 5 / 9	 +400	 45
+	cts5 -	  3		normal	 153	normal	-26005	 5 / 9	 +400	 45
+	cts7 -	  3		normal	 153	1 camp	-26007	 5 / 9	 +400	 45
+	cts9 -	  3		normal	 153	2 camp	-26009	 5 / 9	 +400	 45
+
+	Single camp beams are hard coded to the standard Finland beam 9 and
+	Iceland beam 5.
+
+	Double camp beams are the same for both radars and defined as
+	DOUBLE_CAMP_LOW and DOUBLE_CAMP_HIGH.
+
+	range gates and first range are let to the default settings of 45km
+	and 180km respectively.
+
+	specifying any cts option will override low and high beam, offset, cpIDs,
+	integration time and scan boundary. tbj mode overrides frequencies.
+
+	Modified 05/04/02 PH
+
+	Uses the new stereo aware version of fitacf (1.06).
+
+	Modified 30/04/2002 PH
+
+	Added cpidA and cpidB to set the cpid. This option overrides any
+	previously defined cpid.
+
+	Added bmnA and bmnB to cycle through beams numbers on both channels.
+	To specify double camp beams use -bm0B 5 -bm1B 9
+	To specify single camp beams use -bm0B 5
+	The same beam number can be specified more than once.
+	The number of beams in the channel A beam list determines the number of
+	beams per scan. This is important if you are also using frequency lists.
+
+	cts 2, 3, 4, 5 beams patterns can be changed with bm*A and bm*B options.
+
+	Modified 25/09/02 PH
+
+	Changed so that the B channel frequency band changes at the end of the
+	channel B scan, so that it is independent of the number of beams on
+	channel A.
+
+  Modified 7th Dec 2001 to add camp beam flags
+  Modified 23 Nov 2001 to add new -ns and -fs flags and changed some defaults
+  Modified 10th Aug to account for backwards scanning radars
+  Modified 8th Aug fitacf_s
+  Julian modified version. March 2001
+
+*/
+
+#define CPID_A -6401
+#define CPID_B -26410
+#define CPID_NS 152
+#define CPID_FS 153
+
+
+#define INTT      7
+#define RSEP_A 45
+#define RSEP_B 45
+#define FRANG_A 180
+#define FRANG_B 180
+
+
+#define LOW_BEAM_A   0
+#define HIGH_BEAM_A  15
+#define LOW_BEAM_B   0
+#define HIGH_BEAM_B  15
+
+#define SINGLE_CAMP_BEAM_PYK 5
+#define SINGLE_CAMP_BEAM_HAN 9
+
+
+#define DOUBLE_CAMP_LOW 5
+#define DOUBLE_CAMP_HIGH 9
+
+#define UCONT_NAME "ucont_moni"
+
+#define CHN_A 0
+#define CHN_B 1
+
+#define NUMBANDS 10
+#define NUMBEAMS 16
+
+
+#define SCHEDULER "schedule"
+#define ERRLOG "errlog"
+
+#define CONTROL_NAME "control_program"
+#define TASK_NAMES "echo_data","rawacfwrite","fitacfwrite"
+
+
+
+void u_read_uconts(void);
+void u_init_freq_bands(void);
+
+void RemInvalidEntries(int ifreqsA[], int ifreqsB[]);
+void FindNumBands(int *numfreqbandsA, int *numfreqbandsB, int *day_nightA, int *day_nightB, int ifreqsA[], int ifreqsB[], int print);
+void RemInvalidBeams(int ibeamsA[], int ibeamsB[]);
+void FindNumBeams(int *numbeamsA, int *numbeamsB, int ibeamsA[], int ibeamsB[], int print);
+
+char cmdlne[1024];
+char progid[80]={"$Id: nailedscan.c,v 1.4 2007/08/09 14:09:51 code Exp $"};
+char progname[256];
+struct TaskID *errlog;
+
+int usfreq[42];
+int ufreq_range[42];
+
+pid_t uucont_proxy;
+
+int low_beam_A=LOW_BEAM_A;
+int high_beam_A=HIGH_BEAM_A;
+int low_beam_B=LOW_BEAM_B;
+int high_beam_B=HIGH_BEAM_B;
+
+
+
+
+char *tasklist[]=
+ { TASK_NAMES,
+  0};
+
+int arg=0;
+struct OptionData opt;
+struct OptionFile *optf=NULL;
+      
+int main(int argc,char *argv[]) {
+
+  int ptab[7] = {0,9,12,20,22,26,27};
+
+  int lags[LAG_SIZE][2] = {
+    { 0, 0},		/*  0 */
+    {26,27},		/*  1 */
+    {20,22},		/*  2 */
+    {9,12},		/*  3 */
+    {22,26},		/*  4 */
+    {22,27},		/*  5 */
+
+    {20,26},		/*  7 */
+    {20,27},		/*  8 */
+    {0,9},		/*  9 */
+    {12,22},		/* 10 */
+    {9,20},		/* 11 */
+    {0,12},	  	    /* 12 */
+    {9,22},		/* 13 */
+    {12,26},		/* 14 */
+    {12,27},		/* 15 */
+    {9,26},		/* 16 */
+    {9,27},		/* 17 */
+    {27,27}};		/* alternate lag-0  */
+
+
+  char *sname=NULL;
+  char *ename=NULL;
+  char *sdname={SCHEDULER};
+  char *edname={ERRLOG};
+  char logtxt[1024];
+
+  char a[10];
+
+  int n,i;
+  pid_t sid;
+  int exitpoll=0;
+ 
+  int scnsc=0;
+  int scnus=0;
+ 
+  unsigned char ns=0;
+  unsigned char fs=0;
+
+  int stereo_offset=400; /* channel A delayed by this 
+                            number of microseconds */
+
+
+  int ifreqsA[NUMBANDS],ifreqsB[NUMBANDS];
+
+  int ibeamsA[NUMBEAMS],ibeamsB[NUMBEAMS];
+
+  int day_nightA=1;
+  int day_nightB=1;
+
+  int numfreqbandsA;
+  int numfreqbandsB;
+  
+  int ifreqsA_index=0; 
+  int ifreqsB_index=0;
+  
+  int ifreqsAband;
+  int ifreqsBband;
+
+  int numbeamsA,numbeamsB;
+
+  int ibeamsA_index=0;
+  int ibeamsB_index=0;
+
+  unsigned char cts2=0,cts4=0,cts6=0,cts8=0;
+  unsigned char cts3=0,cts5=0,cts7=0,cts9=0;
+  
+  int cpidA=0,cpidB=0;
+
+  for (i=0;i<NUMBANDS;i++) ifreqsA[i]=ifreqsB[i]=-1;
+  for (i=0;i<NUMBEAMS;i++) ibeamsA[i]=ibeamsB[i]=-1;
+  
+  xcfA=xcfB=1;
+ 
+  cpA=CPID_A;
+  cpB=CPID_B;
+
+  SiteStart();
+ 
+  intsc=INTT;
+  intus=0;
+ 
+  maxattenA=maxattenB=7;
+
+  if ((uucont_proxy=SiteInitProxy(UCONT_NAME))==-1) {
+    perror("cannot attach proxy");
+  }
+ 
+  u_init_freq_bands();
+  
+  strcpy(cmdlne,argv[0]);
+  for (n=1;n<argc;n++) {
+    strcat(cmdlne," ");
+    strcat(cmdlne,argv[n]);
+  } 
+
+  strncpy(combf,progid,80);   
+  OpsSetupCommand(argc,argv);
+  OpsSetupRadar();
+  OpsSetupShell();
+
+  RadarShellAdd(&rstable,"intt",var_LONG,&intsc);
+  RadarShellAdd(&rstable,"inttsc",var_LONG,&intsc);
+  RadarShellAdd(&rstable,"inttus",var_LONG,&intus);
+
+  RadarShellAdd(&rstable,"txplA",var_LONG,&txplA);
+  RadarShellAdd(&rstable,"mpincA",var_LONG,&mpincA);
+  RadarShellAdd(&rstable,"mppulA",var_LONG,&mppulA);
+  RadarShellAdd(&rstable,"mplgsA",var_LONG,&mplgsA);
+  RadarShellAdd(&rstable,"nrangA",var_LONG,&nrangA);
+  RadarShellAdd(&rstable,"frangA",var_LONG,&frangA);
+  RadarShellAdd(&rstable,"rsepA",var_LONG,&rsepA);
+  RadarShellAdd(&rstable,"bmnumA",var_LONG,&bmnumA);
+  RadarShellAdd(&rstable,"xcfA",var_LONG,&xcfA);
+  RadarShellAdd(&rstable,"tfreqA",var_LONG,&tfreqA);
+  RadarShellAdd(&rstable,"scanA",var_LONG,&scanA);
+  RadarShellAdd(&rstable,"mxpwrA",var_LONG,&mxpwrA);
+  RadarShellAdd(&rstable,"lvmaxA",var_LONG,&lvmaxA);
+  RadarShellAdd(&rstable,"rxriseA",var_LONG,&rxriseA);
+  RadarShellAdd(&rstable,"combfA",var_STRING,combfA);
+  RadarShellAdd(&rstable,"cpA",var_LONG,&cpA);
+
+  RadarShellAdd(&rstable,"txplB",var_LONG,&txplB);
+  RadarShellAdd(&rstable,"mpincB",var_LONG,&mpincB);
+  RadarShellAdd(&rstable,"mppulB",var_LONG,&mppulB);
+  RadarShellAdd(&rstable,"mplgsB",var_LONG,&mplgsB);
+  RadarShellAdd(&rstable,"nrangB",var_LONG,&nrangB);
+  RadarShellAdd(&rstable,"frangB",var_LONG,&frangB);
+  RadarShellAdd(&rstable,"rsepB",var_LONG,&rsepB);
+  RadarShellAdd(&rstable,"bmnumB",var_LONG,&bmnumB);
+  RadarShellAdd(&rstable,"xcfB",var_LONG,&xcfB);
+  RadarShellAdd(&rstable,"tfreqB",var_LONG,&tfreqB);
+  RadarShellAdd(&rstable,"scanB",var_LONG,&scanB);
+  RadarShellAdd(&rstable,"mxpwrB",var_LONG,&mxpwrB);
+  RadarShellAdd(&rstable,"lvmaxB",var_LONG,&lvmaxB);
+  RadarShellAdd(&rstable,"rxriseB",var_LONG,&rxriseB);
+  RadarShellAdd(&rstable,"combfB",var_STRING,combfB);
+  RadarShellAdd(&rstable,"cpB",var_LONG,&cpB);
+
+  OptionAdd(&opt, "ns",	'x', &ns);
+  OptionAdd(&opt, "fs",	'x', &fs);
+  OptionAdd(&opt, "e",	't', &ename);  
+  OptionAdd(&opt, "sc",	't', &sname);
+  OptionAdd(&opt, "intt",	'i', &intsc);
+  OptionAdd(&opt, "dfA",	'i', &dfrqA);
+  OptionAdd(&opt, "dfB",	'i', &dfrqB);
+  OptionAdd(&opt, "nfA",	'i', &nfrqA);
+  OptionAdd(&opt, "nfB",	'i', &nfrqB);
+  
+  OptionAdd(&opt, "offset",	'i',&stereo_offset);
+
+  OptionAdd(&opt, "frA",	'i', &frangA);
+  OptionAdd(&opt, "frB",	'i', &frangB);
+  OptionAdd(&opt, "rgA",	'i', &rsepA);
+  OptionAdd(&opt, "rgB",	'i', &rsepB);
+  OptionAdd(&opt, "lbA",	'i', &low_beam_A);
+  OptionAdd(&opt, "hbA",	'i', &high_beam_A);
+  OptionAdd(&opt, "lbB",	'i', &low_beam_B);
+  OptionAdd(&opt, "hbB",	'i', &high_beam_B);
+  OptionAdd(&opt, "sp",	'i', &scnsc);
+
+  OptionAdd(&opt, "cpidA", 'i', &cpidA);
+  OptionAdd(&opt, "cpidB", 'i', &cpidB);
+
+  /* set up remaining shell variables */
+
+  RadarShellAdd(&rstable, "dfA",var_LONG,&dfrqA);
+  RadarShellAdd(&rstable, "dfB",var_LONG,&dfrqB);
+  RadarShellAdd(&rstable, "nfA",var_LONG,&nfrqA);
+  RadarShellAdd(&rstable, "nfB",var_LONG,&nfrqB);
+
+  RadarShellAdd(&rstable, "offset",	var_LONG,&stereo_offset);
+ 
+  RadarShellAdd(&rstable, "low_beamA",	var_LONG,&low_beam_A);
+  RadarShellAdd(&rstable, "high_beamA",var_LONG,&high_beam_A);
+  RadarShellAdd(&rstable, "low_beamB",	var_LONG,&low_beam_B);
+  RadarShellAdd(&rstable, "high_beamB",var_LONG,&high_beam_B);
+  RadarShellAdd(&rstable, "scan_period",var_LONG,&scnsc);
+
+  /* add new options - individual frequency bands */
+
+  strcpy(a,"b0A");
+  for (i = 0; i < NUMBANDS; i++) {
+    a[1] = '0' + i; /* change 2nd char to ACSII number */
+    OptionAdd(&opt, a,	'i', &ifreqsA[i]);
+    RadarShellAdd(&rstable, a, var_LONG, &ifreqsA[i]);
+  }
+
+  strcpy(a,"b0B");
+  for (i = 0; i < NUMBANDS; i++) {
+    a[1] = '0' + i; /* change 2nd char to ACSII number */
+    OptionAdd(&opt, a,	'i', &ifreqsB[i]);
+    RadarShellAdd(&rstable, a, var_LONG, &ifreqsB[i]);
+  }
+
+  strcpy(a,"bm0A");
+  
+  for (i = 0; i < 10; i++) {
+    a[2] = '0' + i;  /* change 3nd char to ACSII number */
+    OptionAdd(&opt, a,	'i', &ibeamsA[i]);
+    RadarShellAdd(&rstable, a, var_LONG, &ibeamsA[i]);
+  }
+
+  strcpy(a,"bm10A");
+  for (i = 0; i < 6; i++) {
+    a[3] = '0' + i;  /* change 4nd char to ACSII number */
+    OptionAdd(&opt, a,	'i', &ibeamsA[i + 10]);
+    RadarShellAdd(&rstable, a, var_LONG, &ibeamsA[i + 10]);
+  }
+
+  strcpy(a,"bm0B");
+  for (i = 0; i < 10; i++) {
+    a[2] = '0' + i;  /* change 3nd char to ACSII number */
+    OptionAdd(&opt, a,	'i', &ibeamsB[i]);
+    RadarShellAdd(&rstable, a, var_LONG, &ibeamsB[i]);
+  }
+
+  strcpy(a,"bm10B");
+  for (i = 0; i < 6; i++) {
+    a[3] = '0' + i; /* change 4nd char to ACSII number */
+    OptionAdd(&opt, a,	'i', &ibeamsB[i + 10]);
+    RadarShellAdd(&rstable, a, var_LONG, &ibeamsB[i + 10]);
+  }
+
+  /* add CTs options */
+
+  OptionAdd(&opt, "cts2", 'x', &cts2);
+  OptionAdd(&opt, "cts3", 'x', &cts3);
+  OptionAdd(&opt, "cts4", 'x', &cts4);
+  OptionAdd(&opt, "cts5", 'x', &cts5);
+  OptionAdd(&opt, "cts6", 'x', &cts6);
+  OptionAdd(&opt, "cts7", 'x', &cts7);
+  OptionAdd(&opt, "cts8", 'x', &cts8);
+  OptionAdd(&opt, "cts9", 'x', &cts9);
+ 
+  arg=OptionProcess(1,argc,argv,&opt,NULL); 
+
+  if (arg<argc) {
+    int farg;
+    FILE *fp=NULL;
+    fp=fopen(argv[arg],"r");
+    if (fp!=NULL) {
+      optf=OptionProcessFile(fp);
+      if (optf !=NULL) {
+        farg=OptionProcess(0,optf->argc,optf->argv,&opt,NULL);
+        OptionFreeFile(optf);
+      }   
+      fclose(fp);
+    }
+  }
+ 
+  if (sname==NULL) sname=sdname;
+  if (ename==NULL) ename=edname;
+
+  sid=RShellRegister(sname,CONTROL_NAME);
+
+  errlog=TaskIDMake(ename);  
+  OpsLogStart(errlog,progname,argc,argv);  
+
+  /* handle CTs */
+
+  if ((cts2) || (cts4) || (cts6) || (cts8)) {
+    cpA = 152;
+	intsc = 7;
+    intus = 0;
+    stereo_offset = 400;
+    scnsc = 120;
+    scnus = 0;
+
+	/* tbj mode */
+
+    if (cts2) {
+	  cpB = -26002;
+      if (stid==9) {
+	    ifreqsB[0] = 23;
+		ifreqsB[1] = 26;
+		ifreqsB[2] = 28;
+		ifreqsB[3] = 30;
+		ifreqsB[4] = 32;
+		ifreqsB[5] = 34;
+		ifreqsB[6] = 35;
+      } else if (stid==10) {
+		ifreqsB[0] = 2;
+		ifreqsB[1] = 4;
+		ifreqsB[2] = 5;
+		ifreqsB[3] = 6;
+		ifreqsB[4] = 7;
+		ifreqsB[5] = 8;
+		ifreqsB[6] = 10;
+      }
+     }
+
+	 /* normal scan */
+
+	 if (cts4) cpB = -26004;
+	
+	 /* single camp beam */
+
+	if (cts6) {
+	  cpB = -26006;
+      if (stid==9) ibeamsB[0] = SINGLE_CAMP_BEAM_PYK;
+      else ibeamsB[0] = SINGLE_CAMP_BEAM_HAN;
+
+	}
+
+	/* double camp beam */
+
+	if (cts8) {
+	  cpB = -26008;
+
+	  ibeamsB[0] = DOUBLE_CAMP_LOW;
+	  ibeamsB[1] = DOUBLE_CAMP_HIGH;
+	}
+  } else if ((cts3) || (cts5) || (cts7) || (cts9)) {
+    cpA = 153;
+	intsc = 3;
+	stereo_offset = 400;
+	scnsc = 60.0;
+    scnus = 0.0;
+
+	/* tbj */
+
+	if (cts3) {
+	  cpB = -26003;
+       
+	  if (stid==9) {
+	    ifreqsB[0] = 23;
+		ifreqsB[1] = 26;
+		ifreqsB[2] = 28;
+		ifreqsB[3] = 30;
+		ifreqsB[4] = 32;
+		ifreqsB[5] = 34;
+		ifreqsB[6] = 35;
+      } else if (stid==10) {
+		ifreqsB[0] = 2;
+		ifreqsB[1] = 4;
+		ifreqsB[2] = 5;
+		ifreqsB[3] = 6;
+		ifreqsB[4] = 7;
+		ifreqsB[5] = 8;
+		ifreqsB[6] = 10;
+      }
+	}
+
+	/* normal scan */
+
+	if (cts5) cpB = -26005;
+	
+
+	/* single camp beam */
+
+	if (cts7) {
+	  cpB = -26007;
+      if (stid==9) ibeamsB[0] = SINGLE_CAMP_BEAM_PYK;
+      else ibeamsB[0] = SINGLE_CAMP_BEAM_HAN;
+
+	}
+
+	/* double camp beam */
+
+	if (cts9) {
+	  cpB = -26009;
+
+	  ibeamsB[0] = DOUBLE_CAMP_LOW;
+	  ibeamsB[1] = DOUBLE_CAMP_HIGH;
+	}
+  } else
+    /* check for normal scan emulation */
+  if (ns) {
+    frangA		= FRANG_A;
+	rsepA		= RSEP_A;
+	low_beam_A	= LOW_BEAM_A;
+	high_beam_A	= HIGH_BEAM_A;
+
+	intsc = 7;
+    intus = 0;
+	scnsc = 120.0;
+    scnus = 0.0;
+	cpA = CPID_NS;  
+  } else
+    /* check for fast scan emulation */
+  if (fs) {
+    frangA		= FRANG_A;
+	rsepA		= RSEP_A;
+	low_beam_A	= LOW_BEAM_A;
+	high_beam_A	= HIGH_BEAM_A;
+
+	intsc = 3;
+    intus = 0;
+	scnsc = 60.0;
+    scnus = 0.0;
+	cpA = CPID_FS;
+  }
+
+  /* set cpid for channel A */
+
+  if (cpidA) {
+     cpA = cpidA;
+	 cpB = -1 * abs(cpidA) - 20000;
+  }
+
+  /* set cpid for channel B */
+
+  if (cpidB) cpB = cpidB;
+	
+  /* Calculate delay offsets
+     If stereo_offset is +ve A is later than B
+  */
+
+  if (stereo_offset > 0) {
+    delays[1] = 0;
+	delays[0] = stereo_offset / 10; /* remember stereo_offset is in usec */
+  } else {
+    delays[0] = 0;
+	delays[1] = (stereo_offset / 10) * (-1); /* stereo_offset is in usec */
+  }
+
+  mppulA = mppulB = 7;
+  mplgsA = mplgsB = 18;
+
+  txplA = (rsepA * 20) / 3;
+  txplB = (rsepB * 20) / 3;
+
+  /* just a dummy frequency */
+
+  tfreqA = 13500;
+  tfreqB = 14500; 
+
+  SiteSetupHardware();
+
+  /* remove invalid entries in the frequency band lists */
+
+  RemInvalidEntries(ifreqsA, ifreqsB);
+
+  /* determine the number of frequency bands */
+
+  FindNumBands(&numfreqbandsA, &numfreqbandsB, 
+               &day_nightA, &day_nightB, ifreqsA, ifreqsB, 1);
+
+  /* check beams */
+
+  if (low_beam_A  <  LOW_BEAM_A) low_beam_A  = LOW_BEAM_A;
+  if (high_beam_A > HIGH_BEAM_A) high_beam_A = HIGH_BEAM_A;
+
+  if (low_beam_B  <  LOW_BEAM_B) low_beam_B  = LOW_BEAM_B;
+  if (high_beam_B > HIGH_BEAM_B) high_beam_B = HIGH_BEAM_B;
+
+  /* end beams in the wrong order */
+
+  if (low_beam_A > high_beam_A) {
+    int beam = high_beam_A;
+    high_beam_A = low_beam_A;
+	low_beam_A  = beam;
+  }
+
+  if (low_beam_B > high_beam_B) {
+    int beam = high_beam_B;
+    high_beam_B = low_beam_B;
+	low_beam_B  = beam;
+  }
+
+  /* sort beam lists */
+
+  RemInvalidBeams(ibeamsA, ibeamsB);			
+  FindNumBeams(&numbeamsA, &numbeamsB, ibeamsA, ibeamsB, 1);
+
+  /*
+	the beam lists now contain:
+	1) the number of beams in the beam lists
+	2) if no beam list or camp beams were specified = 0 -> 15
+	3) if high and low beams were specified			= low_beam -> high_beam
+  */
+   
+  sprintf(progname,"nailedscan");
+
+  OpsFitACFStart();
+
+  OpsSetupTask(tasklist);
+  for (n=0;n<tnum;n++) {
+    RMsgSndReset(tlist[n]);
+    RMsgSndOpen(tlist[n],strlen(cmdlne),cmdlne);     
+  }
+
+  /* scan loop */
+
+  do {
+
+    if (SiteStartScan()==0) continue;
+
+    if (OpsReOpen(2,0,0) !=0) {
+      ErrLog(errlog,progname,"Opening new files.");
+      for (n=0;n<tnum;n++) {
+        RMsgSndClose(tlist[n]);
+        RMsgSndOpen(tlist[n],strlen(cmdlne),cmdlne);     
+      }
+    }
+
+    if (backward) scanA=scanB=-1;
+    else scanA=scanB=1; 
+
+    ErrLog(errlog,progname,"Starting scan.");
+
+
+    for (ibeamsA_index=0;ibeamsA_index<numbeamsA;ibeamsA_index++) {
+
+      bmnumA=ibeamsA[ibeamsA_index];
+      bmnumB=ibeamsB[ibeamsB_index];
+
+	  ifreqsAband = ifreqsA[ifreqsA_index];
+	  ifreqsBband = ifreqsB[ifreqsB_index];
+
+      TimeReadClock(&yr,&mo,&dy,&hr,&mt,&sc,&us);
+
+      if (day_nightA) { 
+        if (OpsDayNight()==1) {
+           stfrqA=usfreq[dfrqA];
+           frqrngA=ufreq_range[dfrqA];
+        } else {
+           stfrqA=usfreq[nfrqA];
+           frqrngA=ufreq_range[nfrqA];
+        } 
+      } else {
+        stfrqA=usfreq[ifreqsAband];
+        frqrngA=ufreq_range[ifreqsAband];
+      }
+
+      if (day_nightB) { 
+        if (OpsDayNight()==1) {
+           stfrqB=usfreq[dfrqB];
+           frqrngB=ufreq_range[dfrqB];
+        } else {
+           stfrqB=usfreq[nfrqB];
+           frqrngB=ufreq_range[nfrqB];
+        } 
+      } else {
+        stfrqB=usfreq[ifreqsBband];
+        frqrngB=ufreq_range[ifreqsBband];
+      }
+
+      SiteSetChannel(CHN_B);
+      SiteSetBeam(bmnumB);
+      SiteSetChannel(CHN_A);
+      SiteSetBeam(bmnumA);
+ 
+      SiteSetIntt(intsc,intus);
+ 
+      if (SiteFCLRS(stfrqA,stfrqA+frqrngA,stfrqB,
+                    stfrqB+frqrngB)==FREQ_LOCAL)
+        ErrLog(errlog,progname,"Frequency Synthesizer in local mode.");
+
+      if (tfreqA==-1) tfreqA=ftable->dfrq;
+      if (tfreqB==-1) tfreqB=ftable->dfrq;
+
+      sprintf(logtxt,"Channel A Transmitting on: %d (Noise=%g)",tfreqA,noiseA);
+      ErrLog(errlog,progname,logtxt);
+
+// nailedscan change
+	  tfreqB=NAILEDFREQ;
+
+      sprintf(logtxt,"Channel B Transmitting on: %d (Noise=%g)",tfreqB,noiseB);
+      ErrLog(errlog,progname,logtxt);
+
+      SiteSetChannel(CHN_A);
+      SiteSetFreq(tfreqA);
+      SiteSetChannel(CHN_B);
+      SiteSetFreq(tfreqB);
+
+	  sprintf(logtxt,"Integrating:%2d,%2d intt:%d (%02d:%02d:%02d) %5d (%02d)  %5d (%02d) - %s  %d\n",
+		      bmnumA, bmnumB, intsc, hr, mt, 
+              sc, tfreqA, ifreqsAband, tfreqB, ifreqsBband, 
+              OpsDayNight() ? "day" : "night", abs(tfreqA - tfreqB));
+
+      ErrLog(errlog,progname,logtxt);
+
+      u_read_uconts();
+
+      txplA = (rsepA * 20) / 3;
+      txplB = (rsepB * 20) / 3;
+
+      tsgidA=SiteTimeSeqS(0,ptab);
+      tsgidB=SiteTimeSeqS(1,ptab);
+
+      SiteIntegrateS(lags,lags);   
+   
+
+      if (naveA<0) {
+        sprintf(logtxt,"Integration A failed:%d",naveA);
+        ErrLog(errlog,progname,logtxt); 
+        continue;
+      }
+      if (naveB<0) {
+        sprintf(logtxt,"Integration B failed:%d",naveB);
+        ErrLog(errlog,progname,logtxt); 
+        continue;
+      }
+
+      sprintf(logtxt,"Number of sequences: %d %d",naveA,naveB);
+      ErrLog(errlog,progname,logtxt);
+
+      OpsBuildRawS(0,&prmA,&rawA,ptab,lags);
+      OpsBuildRawS(1,&prmB,&rawB,ptab,lags);
+
+      FitACF(&prmA,&rawA,&fblk,&fitA);
+      FitACF(&prmB,&rawB,&fblk,&fitB);
+
+      ErrLog(errlog,progname,"Sending messages."); 
+  
+
+      msg.num=0;
+      msg.tsize=0;
+
+      RMsgSndAdd(&msg,sizeof(struct RadarParm),(unsigned char *) &prmA,
+		PRM_TYPE,0); 
+      RMsgSndAdd(&msg,sizeof(struct RawData),(unsigned char *) &rawA,
+		RAW_TYPE,0);    
+
+      RMsgSndAdd(&msg,sizeof(struct FitData),(unsigned char *) &fitA,
+		FIT_TYPE,0);
+
+      RMsgSndAdd(&msg,strlen(progname)+1,progname,
+		NME_TYPE,0);   
+
+      RMsgSndAdd(&msg,sizeof(struct RadarParm),(unsigned char *) &prmB,
+		PRM_TYPE,1); 
+      RMsgSndAdd(&msg,sizeof(struct RawData),(unsigned char *) &rawB,
+		RAW_TYPE,1);    
+
+      RMsgSndAdd(&msg,sizeof(struct FitData),(unsigned char *) &fitB,
+		FIT_TYPE,1);
+
+   
+      RMsgSndAdd(&msg,strlen(progname)+1,progname,
+		NME_TYPE,1);   
+ 
+
+      for (n=0;n<tnum;n++) RMsgSndSend(tlist[n],&msg); 
+  
+      ErrLog(errlog,progname,"Polling for exit."); 
+ 
+      exitpoll=RadarShell(sid,&rstable);
+
+	  /* check the bands and beams here, after radar shell */
+
+	  RemInvalidBeams(ibeamsA, ibeamsB);			
+	  FindNumBeams(&numbeamsA, &numbeamsB, ibeamsA, ibeamsB, 0);
+
+	  RemInvalidEntries(ifreqsA, ifreqsB);
+	  FindNumBands(&numfreqbandsA, &numfreqbandsB, &day_nightA, &day_nightB, ifreqsA, ifreqsB, 0);
+
+	  if (ifreqsA_index >= numfreqbandsA) ifreqsA_index = 0;
+	  if (ifreqsB_index >= numfreqbandsB) ifreqsB_index = 0;
+  
+	  /* Calculate delay offsets if stereo offset has been changed
+         If stereo_offset is +ve A is later than B
+       */
+
+	  if (stereo_offset > 0) {
+	    delays[1] = 0;
+		delays[0] = stereo_offset / 10; /* stereo_offset is in usec */
+ 	  } else {
+		delays[0] = 0;
+		delays[1] = (stereo_offset / 10) * (-1); /* stereo_offset is in usec */
+	  }
+
+	  if (exitpoll !=0) break;
+
+	  scanA = 0;
+	  scanB = 0;
+
+	  /* change beam number index */
+
+	  ibeamsB_index++;
+
+	  if (ibeamsB_index >= numbeamsB) ibeamsB_index = 0;
+
+	  /* change band at the end of channel B scan */
+
+	  if (ibeamsB_index == 0) {
+	    if (numfreqbandsB != 0) {
+		  ifreqsB_index++;
+          if (ifreqsB_index >= numfreqbandsB) ifreqsB_index = 0;
+		}
+	  }
+    } 
+    
+	/* increment individual frequency band index. Doesn't matter whether
+	   individual frequency bands are being used for this channel or not.
+     */
+
+    if (numfreqbandsA != 0) {
+      ifreqsA_index++;
+      if (ifreqsA_index >= numfreqbandsA) ifreqsA_index = 0;
+    }
+
+    ErrLog(errlog,progname,"Waiting for scan boundary."); 
+    if ((scnsc !=0) || (scnus !=0)) {
+      if (exitpoll==0) OpsWaitBoundary(scnsc,scnus);
+    }
+  } while (exitpoll==0);
+  SiteEnd();
+  for (n=0;n<tnum;n++) RMsgSndClose(tlist[n]);
+  ErrLog(errlog,progname,"Ending program.");
+  RShellTerminate(sid);
+  return 0;   
+} 
+ 
+
+/***************************************************************************/
+
+/* Sets up the licenced frequency bands for Iceland & finland */
+
+void u_init_freq_bands() {
+
+/* start freq of each band */
+
+   /* Finland */
+
+   usfreq[0] = 8305;
+   usfreq[1] = 8965;
+   usfreq[2] = 9900;
+   usfreq[3] = 11075;
+   usfreq[4] = 11550;
+   usfreq[5] = 12370;
+   usfreq[6] = 13200;
+   usfreq[7] = 15010;
+   usfreq[8] = 16210;
+   usfreq[9] = 16555;
+   usfreq[10] = 17970;
+   usfreq[11] = 18850;
+   usfreq[12] = 19415;
+   usfreq[13] = 19705;
+   usfreq[14] = 19800;
+
+   /* Iceland */
+
+   usfreq[20] = 8000;
+   usfreq[21] = 8430;
+   usfreq[22] = 8985;
+   usfreq[23] = 10155;
+   usfreq[24] = 10655;
+   usfreq[25] = 11290;
+   usfreq[26] = 11475;
+   usfreq[27] = 12105;
+   usfreq[28] = 12305;
+   usfreq[29] = 12590;
+   usfreq[30] = 13360;
+   usfreq[31] = 13875;
+   usfreq[32] = 14400;
+   usfreq[33] = 15805;
+   usfreq[34] = 16500;
+   usfreq[35] = 16820;
+   usfreq[36] = 18175;
+   usfreq[37] = 18835;
+   usfreq[38] = 19910;
+   usfreq[39] = 10155;
+
+   /* width of each band */
+
+   /* Finland */
+
+   ufreq_range[0] = 30;
+   ufreq_range[1] = 75;
+   ufreq_range[2] = 85;
+   ufreq_range[3] = 200;
+   ufreq_range[4] = 50;
+   ufreq_range[5] = 45;
+   ufreq_range[6] = 60;
+   ufreq_range[7] = 70;
+   ufreq_range[8] = 150;
+   ufreq_range[9] = 60;
+   ufreq_range[10] = 80;
+   ufreq_range[11] = 15;
+   ufreq_range[12] = 265;
+   ufreq_range[13] = 50;
+   ufreq_range[14] = 190; 
+
+   /* Iceland */
+
+   ufreq_range[20] = 195;
+   ufreq_range[21] = 420;
+   ufreq_range[22] = 410;
+   ufreq_range[23] = 500;
+   ufreq_range[24] = 520;
+   ufreq_range[25] = 160;
+   ufreq_range[26] = 120;
+   ufreq_range[27] = 130;
+   ufreq_range[28] = 205;
+   ufreq_range[29] = 690;
+   ufreq_range[30] = 205;
+   ufreq_range[31] = 120;
+   ufreq_range[32] = 615;
+   ufreq_range[33] = 560;
+   ufreq_range[34] = 185;
+   ufreq_range[35] = 655;
+   ufreq_range[36] = 595;
+   ufreq_range[37] = 50;
+   ufreq_range[38] = 90;
+   ufreq_range[39] = 1020;
+}
+
+/* Sends a proxy message to the microcontroller monitoring 
+   task every beam.
+*/
+
+void u_read_uconts() {
+  if (uucont_proxy != 0) Trigger(uucont_proxy);
+}
+
+
+
+/* remove invalid entries in the frequency band lists */
+
+void RemInvalidEntries(int ifreqsA[NUMBANDS], int ifreqsB[NUMBANDS]) {
+  int i, j;
+
+  for (i = NUMBANDS - 1; i > 0; i--) {
+
+	/* if the preceding element is -1 then move all the following
+	   bands down
+     */
+
+	if ((ifreqsA[i] != -1) && (ifreqsA[i - 1] == -1)) {
+	  for (j = i; j < NUMBANDS; j++) {
+	    ifreqsA[j - 1] = ifreqsA[j];
+		ifreqsA[j] = -1;
+	  }
+	}
+
+	if ((ifreqsB[i] != -1) && (ifreqsB[i - 1] == -1)) {
+	  for (j = i; j < NUMBANDS; j++) {
+	    ifreqsB[j - 1] = ifreqsB[j];
+		ifreqsB[j] = -1;
+	  }
+	}
+  }
+}
+
+/* determine the number of frequency bands */
+
+void FindNumBands(int *numfreqbandsA, int *numfreqbandsB, 
+                  int *day_nightA, int *day_nightB, 
+                  int ifreqsA[NUMBANDS], int ifreqsB[NUMBANDS], 
+                  int print) {
+  int i;
+  char logtxt[256];
+
+  *numfreqbandsA = 0;
+  *numfreqbandsB = 0;
+
+  for (i = 0; i < NUMBANDS; i++) {
+    if (ifreqsA[i] != -1) (*numfreqbandsA)++;
+	if (ifreqsB[i] != -1) (*numfreqbandsB)++;
+  }
+
+  /* check to see if day/night frequencies are to be used */
+
+  if (*numfreqbandsA != 0) *day_nightA = 0;
+  else *day_nightA = 1;
+
+  if (*numfreqbandsB != 0) *day_nightB = 0;
+  else *day_nightB = 1;
+
+  if (print) {
+    sprintf(logtxt, "Channel A: %d  Channel B: %d", *numfreqbandsA, 
+            *numfreqbandsB);
+	ErrLog(errlog, progname, logtxt);
+  }
+
+  /* print frequency bands for each channel */
+
+  if ((*numfreqbandsA > 0) && print) {
+    ErrLog(errlog,progname,"Frequency bands for channel A: ");
+
+    for (i = 0; i < *numfreqbandsA; i++) {
+	  sprintf(logtxt, "%1d ", ifreqsA[i]);
+	  ErrLog(errlog,progname,logtxt);
+	}
+  }
+
+  if ((*numfreqbandsB > 0) && print) {
+    ErrLog(errlog,progname,"Frequency bands for channel B: ");
+
+	for (i = 0; i < *numfreqbandsB; i++) {
+	  sprintf(logtxt, "%1d ", ifreqsB[i]);
+	  ErrLog(errlog,progname,logtxt);
+	}
+  }
+}
+
+/* remove invalid entries in the beam lists */
+
+void RemInvalidBeams(int ibeamsA[NUMBEAMS], int ibeamsB[NUMBEAMS]) {
+  int i, j;
+
+  for (i = NUMBEAMS - 1; i > 0; i--) {
+    if (ibeamsA[i] <  0) ibeamsA[i] = -1;
+	if (ibeamsA[i] > 15) ibeamsA[i] = -1;
+
+	if (ibeamsB[i] <  0) ibeamsB[i] = -1;
+	if (ibeamsB[i] > 15) ibeamsB[i] = -1;
+  }
+
+  for (i = NUMBEAMS - 1; i > 0; i--) {
+
+	/* if the preceding element is -1 then move all the 
+       following beams down
+     */
+
+	if ((ibeamsA[i - 1] == -1) && (ibeamsA[i] != -1)) {
+	  for (j = i; j < NUMBEAMS; j++) {
+	    ibeamsA[j - 1] = ibeamsA[j];
+		ibeamsA[j] = -1;
+	  }
+	}
+
+	if ((ibeamsB[i - 1] == -1) && (ibeamsB[i] != -1)) {
+	  for (j = i; j < NUMBEAMS; j++) {
+	    ibeamsB[j - 1] = ibeamsB[j];
+		ibeamsB[j] = -1;
+	  }
+	}
+  }
+}
+
+/* determine the number of beams */
+
+void FindNumBeams(int *numbeamsA, int *numbeamsB, 
+                  int ibeamsA[NUMBEAMS], int ibeamsB[NUMBEAMS], 
+                  int print) {
+  int i;
+  char logtxt[256];
+
+  *numbeamsA = 0;
+  *numbeamsB = 0;
+
+  /* count channel A beams */
+
+  for (i = 0; i < NUMBEAMS; i++) {
+    if (ibeamsA[i] != -1) (*numbeamsA)++;
+	else break;
+  }
+
+  /* count channel B beams */
+
+  for (i = 0; i < NUMBEAMS; i++) {
+    if (ibeamsB[i] != -1) (*numbeamsB)++;
+	else break;
+  }
+
+  if (print) {
+    sprintf(logtxt, "Beams A: %d  Beams B: %d", *numbeamsA, *numbeamsB);
+	ErrLog(errlog, progname, logtxt);
+
+	/* print frequency bands for each channel */
+
+	if (*numbeamsA > 0) {
+	  ErrLog(errlog,progname,"Beams for channel A: ");
+
+	  for (i = 0; i < *numbeamsA; i++) {
+	    sprintf(logtxt, "%1d ", ibeamsA[i]);
+	    ErrLog(errlog,progname,logtxt);
+	  }
+	}
+
+	if (*numbeamsB > 0) {
+	  ErrLog(errlog,progname,"Beams for channel B: ");
+       for (i = 0; i < *numbeamsB; i++) {
+	     sprintf(logtxt, "%1d ", ibeamsB[i]);
+		 ErrLog(errlog,progname,logtxt);
+	   }
+	}
+  }
+
+  /* if no beams have been specified fill the arrays with normal sequence
+     between low_beam and high beam.  
+   */
+  
+  if (*numbeamsA == 0) {
+    if (backward) {
+      for (i = 0; i < (high_beam_A - low_beam_A + 1); i++) {
+        ibeamsA[i] = high_beam_A - i;
+        (*numbeamsA)++;
+ 	  }
+    } else {
+ 	  for (i = 0; i < (high_beam_A - low_beam_A + 1); i++) {
+	    ibeamsA[i] = low_beam_A + i;
+        (*numbeamsA)++;
+	  }
+    }
+  }
+
+  if (*numbeamsB == 0) {
+
+	if (backward) {
+      for (i = 0; i < (high_beam_B - low_beam_B + 1); i++) {
+  	    ibeamsB[i] = high_beam_B - i;
+        (*numbeamsB)++;
+	  }
+    } else {
+  	  for (i = 0; i < (high_beam_B - low_beam_B + 1); i++) {
+        ibeamsB[i] = low_beam_B + i;
+        (*numbeamsB)++;
+	  }
+    }
+  }
+}
+
+
+
+

--- a/qnx4/sd_leicester/han/nailedscan/version.info
+++ b/qnx4/sd_leicester/han/nailedscan/version.info
@@ -1,0 +1,15 @@
+# $Log: version.info,v $
+# Revision 1.4  2007/08/09 14:10:26  code
+# Added the ability to pass command line options as a file.
+#
+# Revision 1.3  2007/08/08 16:56:07  code
+# Fixed bug in using hex notation for stid.
+#
+# Revision 1.2  2006/07/12 15:51:55  code
+# Added call to set up command line and limited data written to rawacf and fitacf.
+#
+# Revision 1.1  2006/03/30 11:28:25  barnes
+# Initial revision
+#
+#
+nailedscan.c 1.04

--- a/qnx4/sd_leicester/han/normalscan.1.08/makefile
+++ b/qnx4/sd_leicester/han/normalscan.1.08/makefile
@@ -1,0 +1,44 @@
+# Makefile for tauscan
+# =======================
+# by R.J.Barnes
+#
+#
+
+
+INCLUDE=-I$(IPATH)/base -I$(IPATH)/general -I$(IPATH)/superdarn \
+	-I$(IPATH)/radarqnx4 \
+	-I$(USR_IPATH)/radarqnx4/ops \
+	-I$(USR_IPATH)/radarqnx4/site.$(SD_RADARCODE)
+
+OBJS = normalscan.o
+SRC=normalscan.c
+IGNVER=1
+OUTPUT = $(USR_BINPATH)/normalscan
+SUDO = 1 
+LIBS=-lsite.${SD_RADARCODE}.1 -lops.1 -lfitacf.1 -lradar.1 -lerrlog.1 \
+      -lrs.1 -lfreq.1 -lacf.1 -ltcpipmsg.1 -lrawfeed.1 -ltsg.1  \
+      -ltaskid.1 -lrmsgsnd.1 -lrtimer.1 -lrtime.1 -lrmath.1 -lopt.1 
+include $(SITELIB).${SD_RADARCODE}
+include $(MAKEBIN)
+
+
+
+
+
+
+  
+
+
+
+
+
+
+
+
+
+  
+
+
+ 
+
+

--- a/qnx4/sd_leicester/han/normalscan.1.08/makefile.bak
+++ b/qnx4/sd_leicester/han/normalscan.1.08/makefile.bak
@@ -1,0 +1,48 @@
+# Makefile for tauscan
+# =======================
+# by R.J.Barnes
+#
+#
+
+
+INCLUDE=-I$(IPATH)/base -I$(IPATH)/general -I$(IPATH)/superdarn \
+	-I$(IPATH)/radarqnx4 \
+	-I$(USR_IPATH)/radarqnx4/ops \
+	-I$(USR_IPATH)/radarqnx4/site.$(SD_RADARCODE)
+
+OBJS = normalscan.o
+SRC=normalscan.c
+IGNVER=1
+OUTPUT = $(USR_BINPATH)/normalscan
+SUDO = 1 
+LIBS=-lsite.${SD_RADARCODE}.1 -lops.1 -lfitacf.1 -lradar.1 -lerrlog.1 \
+     -lfclr.1 -lfclrgc214.1 -lfclrs.1 \
+     -lintegrate.1 -lintegrategc214.1 -lintegrategc214ex.1 \
+     -lintegrates.1 -lrs.1 -lfreq.1 \
+     -lacf.1 -lacfex.1 -lgc214.1 -lad.1 -ldio.1 \
+     -ltcpipmsg.1 -lrawfeed.1 -ltsg.1  \
+     -ltaskid.1 -lrmsgsnd.1 -lrtimer.1 -lrtime.1 -lrmath.1 -lopt.1 
+SLIB=-lm
+include $(MAKEBIN)
+
+
+
+
+
+
+  
+
+
+
+
+
+
+
+
+
+  
+
+
+ 
+
+

--- a/qnx4/sd_leicester/han/normalscan.1.08/normalscan.c
+++ b/qnx4/sd_leicester/han/normalscan.1.08/normalscan.c
@@ -1,0 +1,394 @@
+/* normalscan.c
+   ============
+   Author: R.J.Barnes
+*/
+
+/*
+ Copyright 2004 The Johns Hopkins University/Applied Physics Laboratory.
+ All rights reserved.
+ 
+ This material may be used, modified, or reproduced by or for the U.S.
+ Government pursuant to the license rights granted under the clauses at DFARS
+ 252.227-7013/7014.
+ 
+ For any other permissions, please contact the Space Department
+ Program Office at JHU/APL.
+ 
+ This Distribution and Disclaimer Statement must be included in all copies of
+ "Radar Operating System - Control Programs" (hereinafter "the Program").
+ 
+ The Program was developed at The Johns Hopkins University/Applied Physics
+ Laboratory (JHU/APL) which is the author thereof under the "work made for
+ hire" provisions of the copyright law.  
+ 
+ JHU/APL assumes no obligation to provide support of any kind with regard to
+ the Program.  This includes no obligation to provide assistance in using the
+ Program or to provide updated versions of the Program.
+ 
+ THE PROGRAM AND ITS DOCUMENTATION ARE PROVIDED AS IS AND WITHOUT ANY EXPRESS
+ OR IMPLIED WARRANTIES WHATSOEVER.  ALL WARRANTIES INCLUDING, BUT NOT LIMITED
+ TO, PERFORMANCE, MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE ARE
+ HEREBY DISCLAIMED.  YOU ASSUME THE ENTIRE RISK AND LIABILITY OF USING THE
+ PROGRAM TO INCLUDE USE IN COMPLIANCE WITH ANY THIRD PARTY RIGHTS.  YOU ARE
+ ADVISED TO TEST THE PROGRAM THOROUGHLY BEFORE RELYING ON IT.  IN NO EVENT
+ SHALL JHU/APL BE LIABLE FOR ANY DAMAGES WHATSOEVER, INCLUDING, WITHOUT
+ LIMITATION, ANY LOST PROFITS, LOST SAVINGS OR OTHER INCIDENTAL OR
+ CONSEQUENTIAL DAMAGES, ARISING OUT OF THE USE OR INABILITY TO USE THE
+ PROGRAM."
+ 
+ 
+ 
+ 
+ 
+ 
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/types.h>
+#include <string.h>
+#include <time.h>
+#include "rtypes.h"
+#include "option.h"
+#include "rtime.h"
+#include "limit.h"
+#include "radar.h"
+#include "rprm.h"
+#include "rawdata.h"
+#include "fitblk.h"
+#include "fitdata.h"
+#include "fitacf.h"
+
+
+#include "taskid.h"
+#include "errlog.h"
+#include "rmsg.h"
+#include "radarshell.h"
+#include "rmsgsnd.h"
+#include "tsg.h"
+#include "tsgtable.h"
+#include "maketsg.h"
+#include "global.h"
+#include "setup.h"
+#include "reopen.h"
+#include "tmseq.h"
+#include "raw.h"
+#include "sync.h"
+#include "interface.h"
+#include "hdw.h"
+
+/*
+ $Log: normalscan.c,v $
+ Revision 1.8  2006/07/12 15:48:23  code
+ Added call to set up command line and limited data written to rawacf and fitacf.
+
+ Revision 1.7  2006/02/07 20:55:06  barnes
+ Simon Shepherd's modification to the lag table.
+
+ Revision 1.6  2006/02/07 17:50:17  barnes
+ Fixed bug in calling Errlog.
+
+ Revision 1.5  2006/02/07 17:43:41  barnes
+ Dieter Andre's modification to make integration errors less mysterious.
+
+ Revision 1.4  2005/08/01 18:18:47  barnes
+ Fixed incorrect command line option.
+
+ Revision 1.3  2005/07/19 15:26:59  barnes
+ Added Dieter Andre's extra command line options.
+
+ Revision 1.2  2004/07/23 15:48:27  barnes
+ Fixed bug in beam swinging direction.
+
+ Revision 1.1  2004/05/11 17:43:22  barnes
+ Initial revision
+ 
+*/
+
+#define SCHEDULER "schedule"
+#define ERRLOG "errlog"
+
+#define CONTROL_NAME "control_program"
+#define TASK_NAMES "echo_data","rawacfwrite","fitacfwrite"
+
+char cmdlne[1024];
+char progid[80]={"$Id: normalscan.c,v 1.8 2006/07/12 15:48:23 code Exp $"};
+char progname[256];
+struct TaskID *errlog;
+
+char *tasklist[]=
+ { TASK_NAMES,
+  0};
+
+int arg=0;
+struct OptionData opt;
+      
+int main(int argc,char *argv[]) {
+
+  int ptab[8] = {0,14,22,24,27,31,42,43};
+
+  int lags[LAG_SIZE][2] = {
+    { 0, 0},		/*  0 */
+    {42,43},		/*  1 */
+    {22,24},		/*  2 */
+    {24,27},		/*  3 */
+    {27,31},		/*  4 */
+    {22,27},		/*  5 */
+
+    {24,31},		/*  7 */
+    {14,22},		/*  8 */
+    {22,31},		/*  9 */
+    {14,24},		/* 10 */
+    {31,42},		/* 11 */
+    {31,43},		/* 12 */
+    {14,27},		/* 13 */
+    { 0,14},		/* 14 */
+    {27,42},		/* 15 */
+    {27,43},		/* 16 */
+    {14,31},		/* 17 */
+    {24,42},		/* 18 */
+    {24,43},		/* 19 */
+    {22,42},		/* 20 */
+    {22,43},		/* 21 */
+    { 0,22},		/* 22 */
+
+    { 0,24},		/* 24 */
+
+    {43,43}};		/* alternate lag-0  */
+
+
+  char *sname=NULL;
+  char *ename=NULL;
+  char *sdname={SCHEDULER};
+  char *edname={ERRLOG};
+  char logtxt[1024];
+
+  int n;
+  pid_t sid;
+  int exitpoll=0;
+ 
+  int scnsc=120;
+  int scnus=0;
+  int skip;
+  int cnt=0;
+
+  unsigned char fast=0;
+  unsigned char discretion=0;
+
+  strcpy(cmdlne,argv[0]);
+  for (n=1;n<argc;n++) {
+    strcat(cmdlne," ");
+    strcat(cmdlne,argv[n]);
+  } 
+
+  strncpy(combf,progid,80);   
+  OpsSetupCommand(argc,argv);
+  OpsSetupRadar();
+  OpsSetupShell();
+   
+  RadarShellParse(&rstable,"sbm l ebm l dfrq l nfrq l dfrang l nfrang l dmpinc l nmpinc l frqrng l xcnt l",                        
+                  &sbm,&ebm,                              
+                  &dfrq,&nfrq,                  
+                  &dfrang,&nfrang,                            
+                  &dmpinc,&nmpinc,                            
+                  &frqrng,&xcnt);        
+
+  cp=150;
+  intsc=7;
+  intus=0;
+  mppul=8;
+  mplgs=23;
+  mpinc=1500;
+  dmpinc=1500;
+  nrang=75;
+  rsep=45;
+  txpl=300;
+
+  SiteStart();
+
+  /* ========= PROCESS COMMAND LINE ARGUMENTS ============= */
+
+
+  OptionAdd(&opt,"di",'x',&discretion);
+
+
+  OptionAdd(&opt,"el",'t',&ename);
+  OptionAdd(&opt,"sc",'t',&sname);
+
+  OptionAdd(&opt,"frang",'i',&frang);
+  OptionAdd(&opt,"rsep",'i',&rsep);
+
+  OptionAdd( &opt, "dt", 'i', &day);
+  OptionAdd( &opt, "nt", 'i', &night);
+  OptionAdd( &opt, "df", 'i', &dfrq);
+  OptionAdd( &opt, "nf", 'i', &nfrq);
+  OptionAdd( &opt, "xcf", 'i', &xcnt);
+ 
+  OptionAdd(&opt,"fast",'x',&fast);
+ 
+
+
+  
+  arg=OptionProcess(1,argc,argv,&opt,NULL);  
+ 
+  if (sname==NULL) sname=sdname;
+  if (ename==NULL) ename=edname;
+
+  sid=RShellRegister(sname,CONTROL_NAME);
+
+  errlog=TaskIDMake(ename);  
+  OpsLogStart(errlog,progname,argc,argv);  
+
+  SiteSetupHardware();
+
+  if (fast) {
+     cp=151;
+     scnsc=60;
+     scnus=0;
+     intsc=3;
+     intus=0;
+  }
+
+  if ( discretion) cp= -cp;
+
+  txpl=(rsep*20)/3;
+
+  if (fast) sprintf(progname,"normalscan (fast)");
+  else sprintf(progname,"normalscan");
+
+  OpsFitACFStart();
+
+  OpsSetupTask(tasklist);
+  for (n=0;n<tnum;n++) {
+    RMsgSndReset(tlist[n]);
+    RMsgSndOpen(tlist[n],strlen(cmdlne),cmdlne);     
+  }
+
+  do {
+
+    if (SiteStartScan()==0) continue;
+
+    if (OpsReOpen(2,0,0) !=0) {
+      ErrLog(errlog,progname,"Opening new files.");
+      for (n=0;n<tnum;n++) {
+        RMsgSndClose(tlist[n]);
+        RMsgSndOpen(tlist[n],strlen(cmdlne),cmdlne);     
+      }
+    }
+
+    scan=1;
+
+    ErrLog(errlog,progname,"Starting scan.");
+
+    if (xcnt>0) {
+      cnt++;
+      if (cnt==xcnt) {
+        xcf=1;
+        cnt=0;
+      } else xcf=0;
+    } else xcf=0;
+
+    skip=OpsFindSkip(scnsc,scnus);
+
+    if (backward) {
+      bmnum=sbm-skip;
+      if (bmnum<ebm) bmnum=sbm;
+    } else {
+      bmnum=sbm+skip;
+      if (bmnum>ebm) bmnum=sbm;
+    }
+
+    do {
+
+      TimeReadClock(&yr,&mo,&dy,&hr,&mt,&sc,&us);
+ 
+      if (OpsDayNight()==1) {
+        stfrq=dfrq;
+        mpinc=dmpinc;
+        frang=dfrang;
+      } else {
+        stfrq=nfrq;
+        mpinc=nmpinc;
+        frang=nfrang;
+      }        
+
+      sprintf(logtxt,"Integrating beam:%d intt:%ds.%dus (%d:%d:%d:%d)",bmnum,
+                      intsc,intus,hr,mt,sc,us);
+      ErrLog(errlog,progname,logtxt);
+
+      ErrLog(errlog,progname,"Setting beam.");
+
+      SiteSetIntt(intsc,intus);
+      SiteSetBeam(bmnum);
+
+      ErrLog(errlog,progname,"Doing clear frequency search."); 
+   
+      sprintf(logtxt, "FRQ: %d %d", stfrq, frqrng);
+      ErrLog( errlog, progname, logtxt);
+
+      if (SiteFCLR(stfrq,stfrq+frqrng)==FREQ_LOCAL)
+        ErrLog(errlog,progname,"Frequency Synthesizer in local mode.");
+
+      SiteSetFreq(tfreq);
+
+      sprintf(logtxt,"Transmitting on: %d (Noise=%g)",tfreq,noise);
+
+      ErrLog(errlog,progname,logtxt);
+
+      tsgid=SiteTimeSeq(ptab);
+
+      nave=SiteIntegrate(lags);   
+      if (nave<0) {
+        sprintf(logtxt,"Integration error:%d",nave);
+        ErrLog(errlog,progname,logtxt); 
+        continue;
+      }
+      sprintf(logtxt,"Number of sequences: %d",nave);
+      ErrLog(errlog,progname,logtxt);
+
+
+      OpsBuildRaw(&prm,&raw,ptab,lags);
+
+      FitACF(&prm,&raw,&fblk,&fit);
+
+      ErrLog(errlog,progname,"Sending messages."); 
+  
+
+      msg.num=0;
+      msg.tsize=0;
+
+      RMsgSndAdd(&msg,sizeof(struct RadarParm),(unsigned char *) &prm,
+		PRM_TYPE,0); 
+      RMsgSndAdd(&msg,sizeof(struct RawData),(unsigned char *) &raw,
+		RAW_TYPE,0);    
+
+      RMsgSndAdd(&msg,sizeof(struct FitData),(unsigned char *) &fit,
+		FIT_TYPE,0);   
+      RMsgSndAdd(&msg,strlen(progname)+1,progname,
+		NME_TYPE,0);   
+ 
+
+      for (n=0;n<tnum;n++) RMsgSndSend(tlist[n],&msg); 
+  
+      ErrLog(errlog,progname,"Polling for exit."); 
+    
+      exitpoll=RadarShell(sid,&rstable);
+      if (exitpoll !=0) break;
+      scan=0;
+      if (bmnum==ebm) break;
+      if (backward) bmnum--;
+      else bmnum++;
+
+    } while (1);
+    ErrLog(errlog,progname,"Waiting for scan boundary."); 
+  
+    if (exitpoll==0) OpsWaitBoundary(scnsc,scnus);
+
+  } while (exitpoll==0);
+  SiteEnd();
+  for (n=0;n<tnum;n++) RMsgSndClose(tlist[n]);
+  ErrLog(errlog,progname,"Ending program.");
+  RShellTerminate(sid);
+  return 0;   
+} 
+ 

--- a/qnx4/sd_leicester/han/normalscan.1.08/version.info
+++ b/qnx4/sd_leicester/han/normalscan.1.08/version.info
@@ -1,0 +1,27 @@
+# $Log: version.info,v $
+# Revision 1.8  2006/07/12 15:49:23  code
+# Set up command line.
+#
+# Revision 1.7  2006/02/07 20:56:42  barnes
+# Simon Shepherd's modification to the lag table.
+#
+# Revision 1.6  2006/02/07 17:50:39  barnes
+# Fixed bug in calling Errlog.
+#
+# Revision 1.5  2006/02/07 17:44:14  barnes
+# Dieter Andre's modification to make integration errors less mysterious.
+#
+# Revision 1.4  2005/08/01 18:19:06  barnes
+# Fixed incorrect command line option.
+#
+# Revision 1.3  2005/07/19 15:27:19  barnes
+# Added Dieter Andre's extra command line options.
+#
+# Revision 1.2  2004/07/23 15:49:01  barnes
+# Fixed bug in beam swinging direction.
+#
+# Revision 1.1  2004/05/11 17:43:44  barnes
+# Initial revision
+#
+#
+normalscan.c 1.08

--- a/qnx4/sd_leicester/han/normalsound.2.05/makefile
+++ b/qnx4/sd_leicester/han/normalsound.2.05/makefile
@@ -1,0 +1,44 @@
+# Makefile for tauscan
+# =======================
+# by R.J.Barnes
+#
+#
+
+
+INCLUDE=-I$(IPATH)/base -I$(IPATH)/general -I$(IPATH)/superdarn \
+	-I$(IPATH)/radarqnx4 \
+	-I$(USR_IPATH)/radarqnx4/ops \
+	-I$(USR_IPATH)/radarqnx4/site.$(SD_RADARCODE)
+
+OBJS = normalsound.o
+SRC=normalsound.c
+IGNVER=1
+OUTPUT = $(USR_BINPATH)/normalsound
+SUDO = 1 
+LIBS=-lsite.${SD_RADARCODE}.1 -lops.1 -lfitacf.1 -lradar.1 -lerrlog.1 \
+      -lrs.1 -lfreq.1 -lacf.1 -ltcpipmsg.1 -lrawfeed.1 -ltsg.1  \
+      -ltaskid.1 -lrmsgsnd.1 -lrtimer.1 -lrtime.1 -lrmath.1 -lopt.1 
+include $(SITELIB).${SD_RADARCODE}
+include $(MAKEBIN)
+
+
+
+
+
+
+  
+
+
+
+
+
+
+
+
+
+  
+
+
+ 
+
+

--- a/qnx4/sd_leicester/han/normalsound.2.05/normalsound.c
+++ b/qnx4/sd_leicester/han/normalsound.2.05/normalsound.c
@@ -1,0 +1,966 @@
+/* normalsound.c
+   ============
+   Author: Dieter Andre
+*/
+
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/types.h>
+#include <string.h>
+#include <time.h>
+#include <env.h>
+#include <math.h>
+#include "rtypes.h"
+#include "option.h"
+#include "rtime.h"
+#include "limit.h"
+#include "radar.h"
+#include "rprm.h"
+#include "rawdata.h"
+#include "fitblk.h"
+#include "fitdata.h"
+#include "fitacf.h"
+
+
+#include "taskid.h"
+#include "errlog.h"
+#include "rmsg.h"
+#include "radarshell.h"
+#include "rmsgsnd.h"
+#include "tsg.h"
+#include "tsgtable.h"
+#include "maketsg.h"
+#include "global.h"
+#include "setup.h"
+#include "reopen.h"
+#include "tmseq.h"
+#include "raw.h"
+#include "sync.h"
+#include "interface.h"
+#include "hdw.h"
+
+/*
+ $Log: normalsound.c,v $
+ Revision 2.5  2006/07/12 15:50:19  code
+ Added call to set up command line and limited data written to rawacf and fitacf.
+
+ Revision 2.4  2006/04/13 18:14:36  barnes
+ Incorporated Dieter Andre's bug fix.
+
+ Revision 2.3  2006/02/07 20:55:52  barnes
+ Simon Shepherd's modification to the lag table.
+
+ Revision 2.2  2006/02/07 17:50:57  barnes
+ Added Dieter Andre's improved error logging.
+
+ Revision 2.1  2005/07/19 18:43:54  barnes
+ First revision included in the ROS 1.08.
+
+
+ Revision 2.0  2004/03/23 andre
+ Initial revision from John Hughes program
+ 
+*/
+
+/*======================================================================*/
+/* Program Description:							*/
+/* This version of normalsound runs under ROS 1.08			*/
+/* If you want to run fastsound just run normalsound -fast		*/
+/*									*/
+/* normalsound performs a scan through all 16 beams at 6s or 3s		*/
+/* integration time. In the remaining time until the end of the minute	*/
+/* it performs scans through a set of up to 12 frequencies and through	*/
+/* all beams [even/odd]. This is used to determine the frequency which	*/
+/* gives the most ionospheric scatter from time to time [default 15min]	*/
+/*									*/
+/* The file $SD_HDWPATH/sounder.dat shoudl contain the following values	*/
+/* one per line:							*/
+/* Time between frequency evaluations [min]				*/
+/* Number of sounder frequencies					*/
+/* The sounder frequencies [kHz]					*/
+/*									*/
+/* If this file does not exist, default values are used. This is not a	*/
+/* good idea, as the program may try to sound at forbidden frequencies.	*/
+/*									*/
+/* The sounding data are writen to *.snd files, for each beam one	*/
+/* header and a data record for each good [qflg=1] range.		*/
+/* We have decided to do away with the internal compression, since we	*/
+/* feel, that zipping the files afterwards gives the same result.	*/
+/*									*/
+/* The information used to determine the optimal frequency is kept in	*/
+/* an internal circular buffer, that can hold 1 hour of data. This way	*/
+/* we avoid having to read the files each 15 minutes or so.		*/
+/*									*/
+/* At the moment the whole buffer is used to calculate for each beam	*/
+/* and each sounder frequency :						*/
+/* ( #total_returns - #groundscatter_returns)/ #ranges			*/
+/* These values are then averaged over all beams and if the maximum	*/
+/* gives a sufficient improvement over the presently used one, the	*/
+/* frequency is switched [ see find_optimal_freq for details]		*/
+/*======================================================================*/
+
+#define SCHEDULER "schedule"
+#define ERRLOG "errlog"
+
+#define CONTROL_NAME "control_program"
+#define TASK_NAMES "echo_data","rawacfwrite","fitacfwrite"
+
+char cmdlne[1024];
+char progid[80]={"$Id: normalsound.c,v 2.5 2006/07/12 15:50:19 code Exp $"};
+char progname[256];
+struct TaskID *errlog;
+
+char *tasklist[]=
+ { TASK_NAMES,
+  0};
+
+int arg=0;
+struct OptionData opt;
+
+/* used by cutlass radars */
+/* extern int lsfreq[], lfreq_range[]; */
+
+/* Up to 1 hour of sounding data is stored in this structure */
+
+/* 24* 30/ sounder_intt */
+#define NUM_SND_DATA 360
+#define SND_NRANG 75
+#define SND_NBM 16
+#define SND_NFBIN 26
+#define MAX_SND_FREQS 12
+
+struct sounder_struct
+  {
+  double stime;
+  char program_name[40];
+  int site_id;
+  int beam_num;
+  int freq;
+  int noise;
+  int frange;
+  int rsep;
+  float pwr[ SND_NRANG];
+  float vel[ SND_NRANG];
+  float width[ SND_NRANG];
+  float  AOA[ SND_NRANG];
+  int gsct[ SND_NRANG];
+  int qflg[ SND_NRANG];
+  };
+
+      
+int main(int argc,char *argv[]) {
+
+  int ptab[8] = {0,14,22,24,27,31,42,43};
+
+  int lags[LAG_SIZE][2] = {
+    { 0, 0},    /*  0 */
+    {42,43},    /*  1 */
+    {22,24},    /*  2 */
+    {24,27},    /*  3 */
+    {27,31},    /*  4 */
+    {22,27},    /*  5 */
+
+    {24,31},    /*  7 */
+    {14,22},    /*  8 */
+    {22,31},    /*  9 */
+    {14,24},    /* 10 */
+    {31,42},    /* 11 */
+    {31,43},    /* 12 */
+    {14,27},    /* 13 */
+    { 0,14},    /* 14 */
+    {27,42},    /* 15 */
+    {27,43},    /* 16 */
+    {14,31},    /* 17 */
+    {24,42},    /* 18 */
+    {24,43},    /* 19 */
+    {22,42},    /* 20 */
+    {22,43},    /* 21 */
+    { 0,22},    /* 22 */
+
+    { 0,24},    /* 24 */
+
+    {43,43}};   /* alternate lag-0  */
+
+
+
+  char *sname=NULL;
+  char *ename=NULL;
+  char *sdname={SCHEDULER};
+  char *edname={ERRLOG};
+  char logtxt[1024];
+
+  int n;
+  pid_t sid;
+  int exitpoll=0;
+ 
+  int scnsc=120;
+  int scnus=0;
+  int skip;
+  int cnt=0;
+
+  unsigned char fast=0;
+  unsigned char discretion=0;
+
+  /* Variables for sounding */
+  char snd_filename[ 100];
+  FILE *snd_dat;
+  /* If the file $SD_HDWPATH/sounder.dat exists, the next three parameters are read from it */
+  /* the file contains one integer value per line */
+  int freq_dwell=15; /* after so many minutes a new optimal frequency is evaluated */
+  int sounder_freqs_total=8;
+  int sounder_freqs[ MAX_SND_FREQS]= { 11000, 12000, 13000, 14000, 15000, 16000, 17000, 18000, 0, 0, 0, 0 };
+  time_t last_freq_search, t_now;
+  int fw=0; // frequency weighting flag used in selecting the optimal freq
+  int sounder_beams[]={0,2,4,6,8,10,12,14};
+  int sounder_freq_count=0, sounder_beam_count=0;
+  int sounder_beams_total=8, odd_beams=0;
+  int sounder_freq;
+  int sounder_beam_loop=1;
+  int normal_intt=6;
+  int fast_intt=3;
+  int sounder_intt=2; 
+  int do_new_freq_search=0;
+  float sounder_time, time_needed=1.25;
+  int cutlass=0;
+  struct sounder_struct *sounder_data;
+  int act_snd_rec= 0;
+  
+  sprintf( snd_filename,"%s/sounder.dat", getenv("SD_HDWPATH"));
+  snd_dat= fopen( snd_filename, "r");
+  if( snd_dat != NULL ) {
+    fscanf( snd_dat, "%d", &freq_dwell);
+    fscanf( snd_dat, "%d", &sounder_freqs_total);
+    if (sounder_freqs_total > 12) sounder_freqs_total= 12;
+    for ( sounder_freq_count=0; sounder_freq_count < sounder_freqs_total; sounder_freq_count++ )
+      fscanf( snd_dat, "%d", &sounder_freqs[ sounder_freq_count] );
+    sounder_freq_count= 0;
+    fclose( snd_dat);
+  }
+
+  
+  sounder_data= ( struct sounder_struct *) calloc( sizeof( struct sounder_struct), NUM_SND_DATA);
+  
+  strcpy(cmdlne,argv[0]);
+  for (n=1;n<argc;n++) {
+    strcat(cmdlne," ");
+    strcat(cmdlne,argv[n]);
+  } 
+
+  strncpy(combf,progid,80);   
+  OpsSetupCommand(argc,argv);
+  OpsSetupRadar();
+  OpsSetupShell();
+   
+  RadarShellParse(&rstable,"sbm l ebm l dfrq l nfrq l dfrang l nfrang l dmpinc l nmpinc l frqrng l xcnt l",                        
+                  &sbm,&ebm,                              
+                  &dfrq,&nfrq,                  
+                  &dfrang,&nfrang,                            
+                  &dmpinc,&nmpinc,                            
+                  &frqrng,&xcnt);        
+
+  cp=155; /* normalsound */
+  intsc= normal_intt;
+  intus=0;
+  mppul=8;
+  mplgs=23;
+  mpinc=1500;
+  dmpinc=1500;
+  nrang=75;
+  rsep=45;
+  txpl=300;
+
+  SiteStart();
+  /* need to find out whether this is a CUTLASS-type radar */
+  if( getenv("CUTLASS_ADDRESS")==NULL ) cutlass=0;
+  else cutlass=1;
+
+  /* ========= PROCESS COMMAND LINE ARGUMENTS ============= */
+
+  OptionAdd(&opt,"el",'t',&ename);
+  OptionAdd(&opt,"sc",'t',&sname);
+
+  OptionAdd( &opt, "di", 'x', &discretion);
+  OptionAdd( &opt, "dt", 'i', &day);
+  OptionAdd( &opt, "nt", 'i', &night);
+  OptionAdd( &opt, "df", 'i', &dfrq);
+  OptionAdd( &opt, "nf", 'i', &nfrq);
+  OptionAdd( &opt,"dr",  'i', &dfrang);
+  OptionAdd( &opt,"nr",  'i', &nfrang);
+  OptionAdd( &opt, "dm", 'i', &dmpinc);
+  OptionAdd( &opt, "nm", 'i', &nmpinc);
+  OptionAdd( &opt, "sb", 'i', &sbm);
+  OptionAdd( &opt, "eb", 'i', &ebm);
+  OptionAdd( &opt, "xcf", 'i', &xcnt);
+  OptionAdd(&opt,"fast", 'x', &fast);
+ 
+  arg=OptionProcess(1,argc,argv,&opt,NULL);  
+
+  if (sname==NULL) sname=sdname;
+  if (ename==NULL) ename=edname;
+
+  sid=RShellRegister(sname,CONTROL_NAME);
+
+  errlog=TaskIDMake(ename);  
+  OpsLogStart(errlog,progname,argc,argv);  
+
+  SiteSetupHardware();
+
+  if (fast) {
+     cp= 157; /* fastsound */
+     scnsc=60;
+     scnus=0;
+     intsc= fast_intt;
+     intus=0;
+  }
+  if ( discretion) cp= -cp;
+
+  txpl=(rsep*20)/3;
+
+  if (fast) sprintf(progname,"normalsound (fast)");
+  else sprintf(progname,"normalsound");
+
+  OpsFitACFStart();
+  OpsSetupTask(tasklist);
+  for (n=0;n<tnum;n++) {
+    RMsgSndReset(tlist[n]);
+    RMsgSndOpen(tlist[n],strlen(cmdlne),cmdlne);     
+  }
+
+  /* only set frequency to their default on program start */
+  TimeReadClock(&yr,&mo,&dy,&hr,&mt,&sc,&us);
+  if (OpsDayNight()==1) {
+    stfrq=dfrq;
+  } else {
+    stfrq=nfrq;
+  }
+
+  do {
+
+    if (SiteStartScan()==0) continue;
+    if (OpsReOpen(2,0,0) !=0) {
+      ErrLog(errlog,progname,"Opening new files.");
+      for (n=0;n<tnum;n++) {
+        RMsgSndClose(tlist[n]);
+        RMsgSndOpen(tlist[n],strlen(cmdlne),cmdlne);     
+      }
+    }
+
+    scan=1;
+    ErrLog(errlog,progname,"Starting scan.");
+    if (xcnt>0) {
+      cnt++;
+      if (cnt==xcnt) {
+        xcf=1;
+        cnt=0;
+      } else xcf=0;
+    } else xcf=0;
+
+    skip=OpsFindSkip(scnsc,scnus);
+    if (backward) {
+      bmnum=sbm-skip;
+      if (bmnum<ebm) bmnum=sbm;
+    } else {
+      bmnum=sbm+skip;
+      if (bmnum>ebm) bmnum=sbm;
+    }
+
+    do {
+      TimeReadClock(&yr,&mo,&dy,&hr,&mt,&sc,&us);
+      if (OpsDayNight()==1) {
+        mpinc=dmpinc;
+        frang=dfrang;
+      } else {
+        mpinc=nmpinc;
+        frang=nfrang;
+      }
+
+      sprintf(logtxt,"Integrating beam:%d intt:%ds.%dus (%d:%d:%d:%d)",bmnum,
+                      intsc,intus,hr,mt,sc,us);
+      ErrLog(errlog,progname,logtxt);
+      ErrLog(errlog,progname,"Setting beam.");
+      SiteSetIntt(intsc,intus);
+      SiteSetBeam(bmnum);
+
+      ErrLog(errlog,progname,"Doing clear frequency search."); 
+      if (SiteFCLR(stfrq,stfrq+frqrng)==FREQ_LOCAL)
+        ErrLog(errlog,progname,"Frequency Synthesizer in local mode.");
+      SiteSetFreq(tfreq);
+
+      sprintf(logtxt,"Transmitting on: %d (Noise=%g)",tfreq,noise);
+      ErrLog(errlog,progname,logtxt);
+      tsgid=SiteTimeSeq(ptab);
+      nave=SiteIntegrate(lags);  
+      if (nave < 0) { 
+        sprintf( logtxt, "Integration error: %d", nave);
+        ErrLog(errlog,progname, logtxt); 
+        continue;
+      }
+      sprintf(logtxt,"Number of sequences: %d",nave);
+      ErrLog(errlog,progname,logtxt);
+
+      OpsBuildRaw(&prm,&raw,ptab,lags);
+      FitACF(&prm,&raw,&fblk,&fit);
+
+      ErrLog(errlog,progname,"Sending messages."); 
+      msg.num=0;
+      msg.tsize=0;
+      RMsgSndAdd(&msg,sizeof(struct RadarParm),(unsigned char *) &prm, PRM_TYPE,0); 
+      RMsgSndAdd(&msg,sizeof(struct RawData),(unsigned char *) &raw, RAW_TYPE,0);    
+      RMsgSndAdd(&msg,sizeof(struct FitData),(unsigned char *) &fit, FIT_TYPE,0);   
+      RMsgSndAdd(&msg,strlen(progname)+1,progname, NME_TYPE,0);   
+      for (n=0;n<tnum;n++) RMsgSndSend(tlist[n],&msg); 
+  
+      ErrLog(errlog,progname,"Polling for exit."); 
+      exitpoll=RadarShell(sid,&rstable);
+      if (exitpoll !=0) break;
+      scan=0;
+      if (bmnum==ebm) break;
+      if (backward) bmnum--;
+      else bmnum++;
+
+    } while (1);
+    ErrLog(errlog,progname,"Waiting for scan boundary."); 
+  
+    if (exitpoll==0) {
+      /* In here comes the sounder code */
+      /* see if it's time for a new freq search */
+      time(&t_now);
+      do_new_freq_search= ( freq_dwell>0 && freq_dwell<=((t_now-last_freq_search)/60.) );
+      /* set the "sounder mode" scan variable */
+      scan=-2;
+      /* set the xcf variable to do cross-correlations (AOA) */
+      xcf=1;
+      /* we have time until the end of the minute to do sounding */
+      /* minus a safety factor given in time_needed */
+      TimeReadClock(&yr,&mo,&dy,&hr,&mt,&sc,&us);
+      sounder_time= 60.0 - ( sc + us/ 1000000.0);
+      /* we do not implement to no sounding mode here */
+      /* do a new frequency search if it's time */
+      if( do_new_freq_search && sounder_time>=5 ) {
+	    do_new_freq_search=0;
+	    stfrq= find_optimal_freq( stfrq, cutlass, fw, sounder_freqs, sounder_freqs_total, sounder_data, act_snd_rec);
+        sprintf( logtxt,"New Opt Freq; %d\n", stfrq);
+        ErrLog( errlog, progname, logtxt);
+	    last_freq_search= t_now;
+      }
+      sounder_beam_loop= ( sounder_time-(float)sounder_intt > time_needed );
+      while( sounder_beam_loop ) {
+	    intsc= sounder_intt;
+	    /* set the beam */
+	    bmnum=sounder_beams[sounder_beam_count]+odd_beams;
+	    /* sounder_freq will be an array of frequencies to step through */
+	    if( !cutlass )
+	      sounder_freq=sounder_freqs[sounder_freq_count];
+/*
+	else {
+	  sounder_freq=lsfreq[sounder_freqs[sounder_freq_count]];
+	  frqrng=lfreq_range[sounder_freqs[sounder_freq_count]];
+	}
+*/
+	  /* the scanning code here */	
+	  sprintf(logtxt,"Integrating SND beam:%d intt:%ds.%dus (%d:%d:%d:%d)", bmnum, intsc,intus,hr,mt,sc,us);
+	  ErrLog(errlog,progname,logtxt);
+	  ErrLog(errlog,progname,"Setting SND beam.");
+	  SiteSetIntt(intsc,intus);
+	  SiteSetBeam(bmnum);
+	  ErrLog( errlog, progname, "Doing SND clear frequency search."); 
+	  if (SiteFCLR( sounder_freq, sounder_freq + frqrng)==FREQ_LOCAL)
+        ErrLog(errlog,progname,"Frequency Synthesizer in local mode.");
+	  SiteSetFreq(tfreq);
+/*
+	  sprintf(logtxt,"Transmitting SND on: %d (Noise=%g)",tfreq,noise);
+	  ErrLog( errlog, progname, logtxt);
+*/
+	  tsgid= SiteTimeSeq(ptab);
+	  nave= SiteIntegrate( lags);   
+	  if (nave < 0) {
+            sprintf( logtxt, "SND integration error: %d", nave);
+	    ErrLog(errlog,progname, logtxt); 
+            continue;
+	  }
+	  sprintf(logtxt,"Number of SND sequences: %d",nave);
+	  ErrLog(errlog,progname,logtxt);
+
+	  OpsBuildRaw(&prm,&raw,ptab,lags);
+	  FitACF(&prm,&raw,&fblk,&fit);
+
+	  ErrLog( errlog, progname, "Sending SND messages."); 
+	  msg.num= 0;
+	  msg.tsize= 0;
+	  RMsgSndAdd( &msg, sizeof(struct RadarParm), (unsigned char *) &prm, PRM_TYPE, 0); 
+	  RMsgSndAdd( &msg, sizeof(struct RawData), (unsigned char *) &raw, RAW_TYPE, 0);    
+	  RMsgSndAdd( &msg, sizeof(struct FitData), (unsigned char *) &fit, FIT_TYPE, 0);   
+	  RMsgSndAdd( &msg, strlen(progname)+1, progname, NME_TYPE, 0);
+	  /* Only send these to echo_data; otherwise they get written to the data files */   
+	  RMsgSndSend( tlist[ 0], &msg);
+
+	  sprintf( logtxt, "SBC: %d  SFC: %d\n", sounder_beam_count, sounder_freq_count);
+	  ErrLog( errlog, progname, logtxt);
+	  /* save the sounding mode data */
+	  write_sounding_record_new( progname, &prm, &fit, sounder_data, &act_snd_rec);
+ 
+	  ErrLog( errlog, progname, "Polling SND for exit."); 
+	  exitpoll=RadarShell(sid,&rstable);
+	  if (exitpoll !=0) break;
+
+	  /* check for the end of a beam loop */
+      sounder_freq_count++;
+	  if( sounder_freq_count >= sounder_freqs_total ) {
+	    /* reset the freq counter and increment the beam counter */
+	    sounder_freq_count=0;
+	    sounder_beam_count++;
+	    if( sounder_beam_count>=sounder_beams_total ) {
+	      sounder_beam_count=0;
+	      if( odd_beams==0 )
+	        odd_beams=1;
+	      else
+	        odd_beams=0;
+	      sounder_freq_count=0;
+	    }
+	  }
+	  /* see if we have enough time for another go round */ 
+	  TimeReadClock( &yr, &mo, &dy, &hr, &mt, &sc, &us);
+	  sounder_time= 60.0 - ( sc + us/ 1000000.0);
+	  sounder_beam_loop= ( sounder_time-(float)sounder_intt > time_needed );
+      }
+      /* now wait for the next normal_scan */
+      intsc=normal_intt;
+      if ( fast) intsc= fast_intt;
+      OpsWaitBoundary(scnsc,scnus);
+    }
+
+  } while (exitpoll==0);
+  SiteEnd();
+  for (n=0;n<tnum;n++) RMsgSndClose(tlist[n]);
+  ErrLog(errlog,progname,"Ending program.");
+  RShellTerminate(sid);
+  return 0;   
+} 
+ 
+/********************** function write_sounding_record() ************************/
+void write_sounding_record( char *progname, struct RadarParm *prm, struct FitData *fit, struct sounder_struct *sounder_data, int *act_snd_rec)
+{
+  int i;
+
+  struct header_struct
+	{
+	double stime;
+	unsigned char site_id;
+	unsigned char beam_no;
+	unsigned short freq;
+	unsigned short noise;
+	unsigned short frange;
+	unsigned short rsep;
+	unsigned char gsct[10];
+	unsigned char qflg[10];
+	char program_name[40];
+	short unused1;
+	short unused2;
+	short unused3;
+	} header;
+
+  struct data_struct
+	{
+	short vel;
+	unsigned short width;
+	unsigned short AOA;
+	short unused1;
+	short unused2;
+	unsigned char unused3;
+	unsigned char pwr;
+	} data;
+
+  //char data_path[]={"/data/snd/"}, data_filename[50], filename[80];
+  char data_path[100], data_filename[50], filename[80];
+
+  int byte, good_ranges[75];
+
+  double min_vel=-3000, max_vel=3000;
+  double max_width=1000;
+  double min_power=0, max_power=50;
+  double min_AOA=0, max_AOA=90.;
+
+  char *snd_dir;
+  FILE *out;
+
+  struct sounder_struct *act_snd_data;
+
+
+  /* set up the data directory */
+  /* get the snd data dir */
+  snd_dir= getenv("SD_SND_PATH");
+  if( snd_dir==NULL )
+    sprintf( data_path,"/data/snd/");
+  else
+    memcpy( data_path,snd_dir,strlen(snd_dir));
+//  dpl= strlen( data_path);
+//  if( data_path[ dpl - 1] != '/' ) {
+//    data_path[ dpl]='/';
+//    data_path[ dpl + 1]=0;
+//  } else
+//    data_path[ dpl]=0;
+
+  /* make up the filename */
+  /* YYYYMMDDHH */
+  sprintf( data_filename, "%04d%02d%02d%02d%s", prm->time.yr, prm->time.mo, prm->time.dy, (prm->time.hr/ 2)* 2, getenv("SD_RADARCODE"));
+  /* finally make the filename */
+  sprintf( filename, "%s/%s.snd", data_path, data_filename);
+
+  /* open the output file */
+  out= fopen(filename,"a");
+  if( out==NULL ) {
+	/* crap. might as well go home */
+	return;
+  }
+
+  /* make the header */
+  /* initialize the unused values */
+  //header.unused1=0x0FFE;
+  header.unused1= prm->atten;
+  header.unused2= 0x0FFE;
+  header.unused3= 0x0FFE;
+  data.unused1= 0x0FFE;
+  data.unused2= 0x0FFE;
+  data.unused3= 0xFE;
+
+  header.stime= TimeYMDHMSToEpoch( prm->time.yr, prm->time.mo, prm->time.dy, prm->time.hr, prm->time.mt, prm->time.sc);
+  header.site_id= prm->stid;
+  header.beam_no= prm->bmnum;
+  header.freq= prm->tfreq;
+  header.noise= prm->noise.mean;
+  header.frange= prm->frang;
+  header.rsep= prm->rsep;
+  memcpy( header.program_name, progname, sizeof( header.program_name));
+ /* zero out the gscat and qual bytes */
+  for( i=0; i<10; i++ ) {
+    header.gsct[i]= 0;
+    header.qflg[i]= 0;
+  }
+
+  /* now fill them in */
+  byte= 0;
+  for( i=0; i< SND_NRANG; i++ ) {
+    byte=i/8;
+    if( fit->rng[i].gsct==1 ) header.gsct[byte]+=(0x01<<(i%8));
+    if( fit->rng[i].qflg==1  ) {
+      header.qflg[byte]+= (0x01<<(i%8));
+      good_ranges[i]=1;
+    } else {
+      good_ranges[i]=0;
+    }
+  }
+
+  /* write out the header */
+  fwrite( &header, sizeof( header), 1, out);
+
+  /* scale the fit data into the char/shorts */
+  for( i=0; i< SND_NRANG; i++ ) {
+    /* only do the good ranges */
+    if( good_ranges[i] ) {
+      /* do the power */
+      if( fit->rng[i].p_l < min_power ) data.pwr= 0;
+      else if ( fit->rng[i].p_l > max_power ) data.pwr= 255;
+      else data.pwr= 255* fit->rng[i].p_l/ (max_power - min_power);
+      /* do the AOA */
+      if( fit->elv[i].normal < 0 ) data.AOA= 0;
+      else if( fit->elv[i].normal > 90.0 ) data.AOA= 65535;
+      else data.AOA= 65535* fit->elv[i].normal/ (max_AOA-min_AOA);
+      /* do the velocity */
+      if( fit->rng[i].v < 0 ) {
+        if( fit->rng[i].v < min_vel ) data.vel=-32768;
+        else data.vel= -(32767/ min_vel)* fit->rng[i].v-1;
+      } else {
+        if( fit->rng[i].v > max_vel ) data.vel=32767;
+        else data.vel=(32767/ max_vel)* fit->rng[i].v;
+      }
+      /* do the width */
+      if( fit->rng[i].w_l > max_width ) data.width= 65535;
+      else data.width= ( 65535/ max_width)* fit->rng[i].w_l;
+      /* write out the data structure */
+      fwrite( &data, sizeof( data), 1, out);
+    }
+  }
+  fclose(out);
+
+
+  /* Fill the next sounder data record */
+  act_snd_data= sounder_data + *act_snd_rec;
+  act_snd_data->stime= TimeYMDHMSToEpoch( prm->time.yr, prm->time.mo, prm->time.dy, prm->time.hr, prm->time.mt, prm->time.sc);
+  memcpy( act_snd_data->program_name, progname, sizeof(act_snd_data->program_name));
+  act_snd_data->site_id= prm->stid;
+  act_snd_data->beam_num= prm->bmnum;
+  act_snd_data->freq= prm->tfreq;
+  act_snd_data->noise= prm->noise.mean;
+  act_snd_data->frange= prm->frang;
+  act_snd_data->rsep= prm->rsep;
+  for( i=0; i< SND_NRANG; i++ ) {
+    act_snd_data->pwr[ i]= fit->rng[ i].p_l;
+    act_snd_data->vel[ i]= fit->rng[ i].v;
+    act_snd_data->width[ i]= fit->rng[ i].w_l;
+    act_snd_data->AOA[ i]= fit->elv[ i].normal;
+    act_snd_data->gsct[ i]= fit->rng[ i].gsct;
+    act_snd_data->qflg[ i]= fit->rng[ i].qflg;
+  }
+  *act_snd_rec= *act_snd_rec + 1;
+  if ( *act_snd_rec >= NUM_SND_DATA) *act_snd_rec= 0;
+}
+
+/********************** function write_sounding_record_new() ************************/
+/* changed the data structure */
+
+void write_sounding_record_new( char *progname, struct RadarParm *prm, struct FitData *fit, struct sounder_struct *sounder_data, int *act_snd_rec)
+{
+  int i;
+
+  struct header_struct
+	{
+	long int stime;
+	short int  site_id;
+	short int beam_no;
+	short int freq;
+	short int noise;
+	short int frange;
+	short int rsep;
+	short int gsct[ SND_NRANG];
+	short int qflg[ SND_NRANG];
+	char program_name[40];
+	} header;
+
+  struct data_struct
+	{
+	short int pwr;
+	short int vel;
+	short int width;
+	short int AOA;
+	} data;
+
+  //char data_path[]={"/data/snd/"}, data_filename[50], filename[80];
+  char data_path[100], data_filename[50], filename[80];
+ 
+
+  int  good_ranges[ SND_NRANG];
+
+  char *snd_dir;
+  FILE *out;
+
+  struct sounder_struct *act_snd_data;
+
+
+  /* set up the data directory */
+  /* get the snd data dir */
+  snd_dir= getenv("SD_SND_PATH");
+  if( snd_dir==NULL )
+    sprintf( data_path,"/data/snd/");
+  else {
+    memcpy( data_path,snd_dir,strlen(snd_dir));
+    data_path[ strlen( snd_dir)]= '/';
+    data_path[ strlen( snd_dir) + 1]= 0;
+  }
+
+  /* make up the filename */
+  /* YYYYMMDDHH */
+  sprintf( data_filename, "%04d%02d%02d%02d%s", prm->time.yr, prm->time.mo, prm->time.dy, (prm->time.hr/ 2)* 2, getenv("SD_RADARCODE"));
+  /* finally make the filename */
+  sprintf( filename, "%s%s.snd", data_path, data_filename);
+  /* open the output file */
+  out= fopen(filename,"a");
+  if( out==NULL ) {
+	/* crap. might as well go home */
+	return;
+  }
+
+  /* make the header */
+
+  header.stime= TimeYMDHMSToEpoch( prm->time.yr, prm->time.mo, prm->time.dy, prm->time.hr, prm->time.mt, prm->time.sc);
+  header.site_id= prm->stid;
+  header.beam_no= prm->bmnum;
+  header.freq= prm->tfreq;
+  header.noise= prm->noise.mean;
+  header.frange= prm->frang;
+  header.rsep= prm->rsep;
+  memcpy( header.program_name, progname, sizeof( header.program_name));
+ /* zero out the gscat and qual bytes */
+  for( i=0; i< SND_NRANG; i++ ) {
+    header.gsct[i]= fit->rng[i].gsct;
+    header.qflg[i]= fit->rng[i].qflg;
+    good_ranges[ i]= ( fit->rng[i].qflg == 1);
+  }
+
+  /* write out the header */
+  fwrite( &header, sizeof( header), 1, out);
+
+  /* scale the fit data into the char/shorts */
+  for( i=0; i< SND_NRANG; i++ ) {
+    /* only do the good ranges */
+    if( good_ranges[i] ) {
+      /* do the power */
+      data.pwr= fit->rng[i].p_l;
+      /* do the velocity */
+      data.vel= fit->rng[i].v;
+      /* do the AOA */
+      data.AOA= fit->elv[i].normal;
+      /* do the width */
+      data.width= fit->rng[i].w_l;
+      /* write out the data structure */
+      fwrite( &data, sizeof( data), 1, out);
+    }
+  }
+  fclose(out);
+
+
+  /* Fill the next sounder data record */
+  act_snd_data= sounder_data + *act_snd_rec;
+  act_snd_data->stime= TimeYMDHMSToEpoch( prm->time.yr, prm->time.mo, prm->time.dy, prm->time.hr, prm->time.mt, prm->time.sc);
+  memcpy( act_snd_data->program_name, progname, sizeof(act_snd_data->program_name));
+  act_snd_data->site_id= prm->stid;
+  act_snd_data->beam_num= prm->bmnum;
+  act_snd_data->freq= prm->tfreq;
+  act_snd_data->noise= prm->noise.mean;
+  act_snd_data->frange= prm->frang;
+  act_snd_data->rsep= prm->rsep;
+  for( i=0; i< SND_NRANG; i++ ) {
+    act_snd_data->pwr[ i]= fit->rng[ i].p_l;
+    act_snd_data->vel[ i]= fit->rng[ i].v;
+    act_snd_data->width[ i]= fit->rng[ i].w_l;
+    act_snd_data->AOA[ i]= fit->elv[ i].normal;
+    act_snd_data->gsct[ i]= fit->rng[ i].gsct;
+    act_snd_data->qflg[ i]= fit->rng[ i].qflg;
+  }
+  *act_snd_rec= *act_snd_rec + 1;
+  if ( *act_snd_rec >= NUM_SND_DATA) *act_snd_rec= 0;
+}
+
+/****************** function compute_scatter_percentage *************************/
+/* Mod: 20050315																*/
+/* Use ths last ~15min sounder data to calculate the ionospheric scatter percentage */
+/* for each sounder frequency and in each beam									*/
+/* a lot more could be done, but for now we will keep it simple					*/
+
+void compute_scatter_percentage( struct sounder_struct *sounder_data, int act_snd_rec, int sounder_freqs[], int sft, float iscat_percent[ MAX_SND_FREQS][ SND_NBM] )
+{
+  struct sounder_struct *act_snd_data;
+  int isnd, jsnd, ifrq, i;
+  int returns=0, gscat_returns=0;
+  
+  for ( jsnd=0; jsnd< NUM_SND_DATA/ 4; jsnd++) {
+    isnd= act_snd_rec - jsnd;
+    if (isnd < 0) isnd= isnd + NUM_SND_DATA;
+    act_snd_data= sounder_data + isnd;
+    /* make sure this record has data */
+    if (act_snd_data->stime > 0 ) {
+      returns=0;
+      gscat_returns=0;
+      for( i=0; i< SND_NRANG; i++ ) {
+	if( ( act_snd_data->qflg[i] == 1) && act_snd_data->pwr[i] >= 3.0 && act_snd_data->width[i] < 500.0 ) {
+	  returns++;
+	  if( act_snd_data->gsct[i] ) gscat_returns++;
+	}
+      }
+     for ( ifrq=0; ifrq< sft; ifrq++) {
+       if ( (act_snd_data->freq >= sounder_freqs[ ifrq]) && (act_snd_data->freq <= sounder_freqs[ ifrq] + frqrng) )
+         break;
+     }
+     iscat_percent[ ifrq][act_snd_data->beam_num]= 100.0* (float)(returns - gscat_returns)/ SND_NRANG;
+    }
+  }
+}
+
+/****************** function average_scatter_percentage *************************/
+/* what is fw good for ?? */
+
+void average_scatter_percentages( float iscat_percent[ MAX_SND_FREQS][ SND_NBM], int sft, float average_iscat_percent[ MAX_SND_FREQS], int fw )
+{
+int ifrq, ibm;
+
+  /* average the scatter percentages over all beams */
+  for( ifrq=0; ifrq < sft; ifrq++ ) {
+    average_iscat_percent[ifrq]= 0.0;
+    for( ibm=0; ibm < SND_NBM; ibm++ )
+      average_iscat_percent[ ifrq]+= iscat_percent[ ifrq][ ibm];
+    average_iscat_percent[ ifrq]/= 16.0;
+    if( fw ) average_iscat_percent[ ifrq]*= ifrq;
+  }
+}
+
+/******************* function find_optimal_freq_local() ************************/
+/* our frequency optimization scheme is this:                          */
+/*                                                                     */
+/* at each frequency, find the most recent set of range data for each  */
+/* beam. filter this data and then find the percentage of data points  */
+/* that were ionospheric backscatter. to get the optimal frequency,    */
+/* average over all beams at each frequency and look for the freq      */
+/* with the highest percentage of ionsopheric backscatter.             */
+
+int find_optimal_freq(int start_freq, int cutlass, int fw, int sounder_freqs[], int sft, struct sounder_struct *sounder_data, int act_snd_rec)
+{
+  int i,j;
+  int def_freq, def_freq_bin;
+  /* array of iono scatter percentages (freq and beam number) */
+  float iscat_percent[ MAX_SND_FREQS][ SND_NBM];
+  float average_iscat_percent[ MAX_SND_FREQS];
+  float max_scatter=-10;
+  int max_freq_bin=0;
+  int dlf;
+  FILE *out;
+ 
+
+  /* set the optimal freq to the sounder frequency closest to start_freq in case we don't find a good one; 20060308 DAndre */
+  if( !cutlass ) {
+    dlf= 100000;
+    for ( i= 0; i < sft; i++) { 
+      if ( fabs( start_freq - sounder_freqs[ i]) < dlf) {
+        dlf= fabs( start_freq - sounder_freqs[ i]);
+        def_freq_bin= i;
+      }
+    }
+  }
+/*
+  else
+    def_freq_bin=lsfreq[def_freq]/1000;
+*/
+
+  /* initialize the arrays */
+  for( i=0; i<MAX_SND_FREQS; i++ )
+    for( j=0; j<SND_NBM; j++ ) {
+      iscat_percent[i][j]=0;
+    }
+
+  compute_scatter_percentage( sounder_data, act_snd_rec, sounder_freqs, sft, iscat_percent);
+  average_scatter_percentages( iscat_percent, sft, average_iscat_percent, fw );
+  max_scatter=-10;
+  for( i=0; i< sft; i++ )
+    if( average_iscat_percent[i] >= max_scatter ) {
+      max_scatter= average_iscat_percent[ i];
+      max_freq_bin=i;
+    }
+
+  /* set a threshold on the improvement */
+  if( max_scatter < 1.15* average_iscat_percent[def_freq_bin] || ( max_scatter - average_iscat_percent[def_freq_bin]) < 0.75 )
+    max_freq_bin=def_freq_bin;
+
+  def_freq= sounder_freqs[ max_freq_bin];
+
+  out=fopen("/tmp/freq_search.out","w");
+  if( out != NULL ) {
+    for( i= 0; i < sft; i++ ) {
+      if( !fw ) 
+	fprintf(out,"\n%2d %d %10.7lf", i, sounder_freqs[ i], average_iscat_percent[i]); 
+      else
+	fprintf(out,"\n%2d %d %10.7lf", i, sounder_freqs[ i], average_iscat_percent[i]/ i); 
+    }
+    fprintf( out, "\nCutlass: %d",cutlass);
+    fprintf( out, "\nFreq Weighting: %d",fw);
+    fprintf( out, "\nReturned Frequency: %d kHz",def_freq);
+    fprintf( out, "\n");
+    fclose(out);
+  }
+
+  return(def_freq);
+}
+
+
+
+
+
+

--- a/qnx4/sd_leicester/han/normalsound.2.05/version.info
+++ b/qnx4/sd_leicester/han/normalsound.2.05/version.info
@@ -1,0 +1,19 @@
+#$Log: version.info,v $
+#Revision 2.5  2006/07/12 15:50:45  code
+#Added call to set up command line and limited data written to rawacf and fitacf.
+#
+#Revision 2.4  2006/04/13 18:14:56  barnes
+#Incorporated Dieter Andre's bug fix.
+#
+#Revision 2.3  2006/02/07 20:56:24  barnes
+#Simon Shepherd's modification to the lag table.
+#
+#Revision 2.2  2006/02/07 17:51:13  barnes
+#Added Dieter Andre's improved error logging.
+#
+#Revision 2.1  2005/07/19 18:45:06  barnes
+#First revision included in the ROS 1.08.
+#
+#
+normalsound.c 2.05
+

--- a/qnx4/sd_leicester/han/pcpstereoscan.1.02/makefile
+++ b/qnx4/sd_leicester/han/pcpstereoscan.1.02/makefile
@@ -1,0 +1,55 @@
+# Makefile for stereoscan
+# =======================
+# by R.J.Barnes
+#
+#
+
+
+INCLUDE=-I$(IPATH)/base -I$(IPATH)/general -I$(IPATH)/superdarn \
+	-I$(IPATH)/radarqnx4 \
+	-I$(USR_IPATH)/radarqnx4/ops \
+	-I$(USR_IPATH)/radarqnx4/site.$(SD_RADARCODE)
+
+OBJS = pcpstereoscan.o
+SRC=pcpstereoscan.c
+IGNVER=1
+OUTPUT = $(USR_BINPATH)/pcpstereoscan
+SUDO = 1 
+LIBS=-lsite.${SD_RADARCODE}.1 -lops.1 -lfitacf.1 -lradar.1 -lerrlog.1 \
+     -lrs.1 -lfreq.1 -lacf.1 -ltcpipmsg.1 -lrawfeed.1 -ltsg.1  \
+     -ltaskid.1 -lrmsgsnd.1 -lrtimer.1 -lrtime.1 -lrmath.1 -lopt.1 
+
+include $(SITELIB).${SD_RADARCODE}
+
+ifdef STEREO
+include $(MAKEBIN)
+else
+version: version.info $(SRC)
+	$(BINPATH)/rcsv -t version.info
+clean:
+	rm -f *.o
+	rm -f $(OUTPUT)
+endif
+
+
+
+
+
+
+
+  
+
+
+
+
+
+
+
+
+
+  
+
+
+ 
+
+

--- a/qnx4/sd_leicester/han/pcpstereoscan.1.02/pcpstereoscan.c
+++ b/qnx4/sd_leicester/han/pcpstereoscan.1.02/pcpstereoscan.c
@@ -1,0 +1,874 @@
+/* stereoscan.c
+   ============
+   Author: R.J.Barnes
+*/
+
+/*
+ Copyright 2004 The Johns Hopkins University/Applied Physics Laboratory.
+ All rights reserved.
+ 
+ This material may be used, modified, or reproduced by or for the U.S.
+ Government pursuant to the license rights granted under the clauses at DFARS
+ 252.227-7013/7014.
+ 
+ For any other permissions, please contact the Space Department
+ Program Office at JHU/APL.
+ 
+ This Distribution and Disclaimer Statement must be included in all copies of
+ "Radar Operating System - Control Programs" (hereinafter "the Program").
+ 
+ The Program was developed at The Johns Hopkins University/Applied Physics
+ Laboratory (JHU/APL) which is the author thereof under the "work made for
+ hire" provisions of the copyright law.  
+ 
+ JHU/APL assumes no obligation to provide support of any kind with regard to
+ the Program.  This includes no obligation to provide assistance in using the
+ Program or to provide updated versions of the Program.
+ 
+ THE PROGRAM AND ITS DOCUMENTATION ARE PROVIDED AS IS AND WITHOUT ANY EXPRESS
+ OR IMPLIED WARRANTIES WHATSOEVER.  ALL WARRANTIES INCLUDING, BUT NOT LIMITED
+ TO, PERFORMANCE, MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE ARE
+ HEREBY DISCLAIMED.  YOU ASSUME THE ENTIRE RISK AND LIABILITY OF USING THE
+ PROGRAM TO INCLUDE USE IN COMPLIANCE WITH ANY THIRD PARTY RIGHTS.  YOU ARE
+ ADVISED TO TEST THE PROGRAM THOROUGHLY BEFORE RELYING ON IT.  IN NO EVENT
+ SHALL JHU/APL BE LIABLE FOR ANY DAMAGES WHATSOEVER, INCLUDING, WITHOUT
+ LIMITATION, ANY LOST PROFITS, LOST SAVINGS OR OTHER INCIDENTAL OR
+ CONSEQUENTIAL DAMAGES, ARISING OUT OF THE USE OR INABILITY TO USE THE
+ PROGRAM."
+ 
+ 
+ 
+ 
+ 
+  
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/types.h>
+#include <sys/proxy.h>
+#include <sys/kernel.h>
+#include <string.h>
+#include <time.h>
+#include "rtypes.h"
+#include "option.h"
+#include "rtime.h"
+#include "limit.h"
+#include "radar.h"
+#include "rprm.h"
+#include "rawdata.h"
+#include "fitblk.h"
+#include "fitdata.h"
+#include "fitacf.h"
+
+#include "taskid.h"
+#include "errlog.h"
+#include "freq.h"
+#include "rmsg.h"
+#include "radarshell.h"
+#include "rmsgsnd.h"
+#include "tsg.h"
+#include "tsgtable.h"
+#include "maketsg.h"
+#include "global.h"
+#include "globals.h"
+#include "setup.h"
+#include "reopen.h"
+#include "tmseq.h"
+#include "raws.h"
+#include "sync.h"
+#include "interface.h"
+#include "hdw.h"
+
+/*
+ $Log: pcpstereoscan.c,v $
+ Revision 1.2  2006/07/12 15:51:43  code
+ Added call to set up command line and limited data written to rawacf and fitacf.
+
+ Revision 1.1  2006/03/30 11:19:18  barnes
+ Initial revision
+ 
+*/
+
+/*
+	Modified 10/12/2001 PH
+
+	Added bnA and bnB frequency band options to cycle through frequency
+	bands during each scan. No check is made for invalid band numbers.
+	A band number of -1 is ignored. Bands can be added/removed at any
+	time using radar_shell, changes won't take effect until the end of
+	the current scan. If no band numbers are specified, normal day/night
+	frequencies are used.
+
+	Frequency bands can also be specified for campA and campB modes.
+
+	Extra options can be placed in a separate schedule file. The file
+	name should be the last argument in the schedule argument list and
+	should include the full path.
+
+	Modified 16/01/02 PH
+
+	Fixed synchronisation bug. The code wasn't subtracting the time taken
+	for a clear frequency search from the beam integration time, resulting
+	in an extended beam dwell time and a sweep lasting for more than 60 s
+	for fast stereo and 120 s for slow stereo 7 s integration.
+
+	Standard slow stereo (normal stereo) is now 7 seconds (by Mark Lester).
+
+	Modified 30/01/02 PH
+
+	added -cts? options that pre-set other options
+
+			dwell	chan A	cpidA	chan B	cpidB	Ice/Fin	offset	range
+			------	------	------	------	------	------- ------	-----
+	cts2 -    7		normal	 152	 tbj	-26002	 5 / 9	 +400	 45
+	cts4 -	  7		normal	 152	normal	-26004	 5 / 9	 +400	 45
+	cts6 -	  7		normal	 152	1 camp	-26006	 5 / 9	 +400	 45
+	cts8 -	  7		normal	 152	2 camp	-26008	 5 / 9	 +400	 45
+
+	cts3 -	  3		normal	 153	 tbj	-26003	 5 / 9	 +400	 45
+	cts5 -	  3		normal	 153	normal	-26005	 5 / 9	 +400	 45
+	cts7 -	  3		normal	 153	1 camp	-26007	 5 / 9	 +400	 45
+	cts9 -	  3		normal	 153	2 camp	-26009	 5 / 9	 +400	 45
+
+	Single camp beams are hard coded to the standard Finland beam 9 and
+	Iceland beam 5.
+
+	Double camp beams are the same for both radars and defined as
+	DOUBLE_CAMP_LOW and DOUBLE_CAMP_HIGH.
+
+	range gates and first range are let to the default settings of 45km
+	and 180km respectively.
+
+	specifying any cts option will override low and high beam, offset, cpIDs,
+	integration time and scan boundary. tbj mode overrides frequencies.
+
+	Modified 05/04/02 PH
+
+	Uses the new stereo aware version of fitacf (1.06).
+
+	Modified 30/04/2002 PH
+
+	Added cpidA and cpidB to set the cpid. This option overrides any
+	previously defined cpid.
+
+	Added bmnA and bmnB to cycle through beams numbers on both channels.
+	To specify double camp beams use -bm0B 5 -bm1B 9
+	To specify single camp beams use -bm0B 5
+	The same beam number can be specified more than once.
+	The number of beams in the channel A beam list determines the number of
+	beams per scan. This is important if you are also using frequency lists.
+
+	cts 2, 3, 4, 5 beams patterns can be changed with bm*A and bm*B options.
+
+	Modified 25/09/02 PH
+
+	Changed so that the B channel frequency band changes at the end of the
+	channel B scan, so that it is independent of the number of beams on
+	channel A.
+
+  Modified 7th Dec 2001 to add camp beam flags
+  Modified 23 Nov 2001 to add new -ns and -fs flags and changed some defaults
+  Modified 10th Aug to account for backwards scanning radars
+  Modified 8th Aug fitacf_s
+  Julian modified version. March 2001
+
+*/
+
+/* set CPIDs for this experiment, 9212 is CPID provided by UAF for polar cap patch experiment
+   -26999 is dummy CPID for the non-existent channelB */
+#define CPID_A 9212
+#define CPID_B -26999
+
+
+#define INTT      3
+#define RSEP_A 15
+#define RSEP_B 15
+#define FRANG_A 180
+#define FRANG_B 180
+
+
+#define LOW_BEAM_A   0
+#define HIGH_BEAM_A  15
+#define LOW_BEAM_B   0
+#define HIGH_BEAM_B  15
+
+#define SINGLE_CAMP_BEAM_PYK 5
+#define SINGLE_CAMP_BEAM_HAN 9
+
+
+#define DOUBLE_CAMP_LOW 5
+#define DOUBLE_CAMP_HIGH 9
+
+#define UCONT_NAME "ucont_moni"
+
+#define CHN_A 0
+#define CHN_B 1
+
+#define NUMBANDS 10
+#define NUMBEAMS 16
+
+
+#define SCHEDULER "schedule"
+#define ERRLOG "errlog"
+
+#define CONTROL_NAME "control_program"
+#define TASK_NAMES "echo_data","rawacfwrite","fitacfwrite"
+
+#define PCPBEAM 9
+#define PCPFNUM 8
+int pcpfreqs[PCPFNUM]; 
+int pcpcnt;
+
+void u_read_uconts(void);
+void u_init_freq_bands(void);
+
+char cmdlne[1024];
+char progid[80]={"$Id: pcpstereoscan.c,v 1.2 2011/12/13 15:51:43 code Exp $"};
+char progname[256];
+struct TaskID *errlog;
+
+int usfreq[42];
+int ufreq_range[42];
+
+pid_t uucont_proxy;
+
+int low_beam_A=LOW_BEAM_A;
+int high_beam_A=HIGH_BEAM_A;
+int low_beam_B=LOW_BEAM_B;
+int high_beam_B=HIGH_BEAM_B;
+
+
+
+
+char *tasklist[]=
+ { TASK_NAMES,
+  0};
+
+int arg=0;
+struct OptionData opt;
+      
+int main(int argc,char *argv[]) {
+
+  int ptab[7] = {0,9,12,20,22,26,27};
+
+  int lags[LAG_SIZE][2] = {
+    { 0, 0},		/*  0 */
+    {26,27},		/*  1 */
+    {20,22},		/*  2 */
+    {9,12},		/*  3 */
+    {22,26},		/*  4 */
+    {22,27},		/*  5 */
+
+    {20,26},		/*  7 */
+    {20,27},		/*  8 */
+    {0,9},		/*  9 */
+    {12,22},		/* 10 */
+    {9,20},		/* 11 */
+    {0,12},	  	    /* 12 */
+    {9,22},		/* 13 */
+    {12,26},		/* 14 */
+    {12,27},		/* 15 */
+    {9,26},		/* 16 */
+    {9,27},		/* 17 */
+    {27,27}};		/* alternate lag-0  */
+
+
+  char *sname=NULL;
+  char *ename=NULL;
+  char *sdname={SCHEDULER};
+  char *edname={ERRLOG};
+  char logtxt[1024];
+
+  char a[10];
+
+  int n,i;
+  pid_t sid;
+  int exitpoll=0;
+ 
+  int scnsc=0;
+  int scnus=0;
+ 
+  unsigned char ns=0;
+  unsigned char fs=0;
+
+  int stereo_offset=400; /* channel A delayed by this 
+                            number of microseconds */
+
+
+  int ifreqsA[NUMBANDS],ifreqsB[NUMBANDS];
+
+  int day_nightA=1;
+  int day_nightB=1;
+
+  int numfreqbandsA;
+  int numfreqbandsB;
+
+  int ifreqsA_index=0; 
+  int ifreqsB_index=0;
+  
+  int ifreqsAband;
+  int ifreqsBband;
+
+  int sbm, ebm, bmnm[16], bmcnt;
+
+  int numbeamsA,numbeamsB;
+
+  unsigned char cts2=0,cts4=0,cts6=0,cts8=0;
+  unsigned char cts3=0,cts5=0,cts7=0,cts9=0;
+  
+  int cpidA=0,cpidB=0;
+
+  xcfA=xcfB=1;
+ 
+  cpA=CPID_A;
+  cpB=CPID_B;
+
+  SiteStart();
+ 
+  intsc=INTT;
+  intus=0;
+ 
+  maxattenA=maxattenB=7;
+
+  if ((uucont_proxy=SiteInitProxy(UCONT_NAME))==-1) {
+    perror("cannot attach proxy");
+  }
+ 
+  u_init_freq_bands();
+  
+  strcpy(cmdlne,argv[0]);
+  for (n=1;n<argc;n++) {
+    strcat(cmdlne," ");
+    strcat(cmdlne,argv[n]);
+  } 
+printf("** 1\n");
+  strncpy(combf,progid,80);   
+  OpsSetupCommand(argc,argv);
+  OpsSetupRadar();
+  OpsSetupShell();
+
+  RadarShellAdd(&rstable,"intt",var_LONG,&intsc);
+  RadarShellAdd(&rstable,"inttsc",var_LONG,&intsc);
+  RadarShellAdd(&rstable,"inttus",var_LONG,&intus);
+
+  RadarShellAdd(&rstable,"txplA",var_LONG,&txplA);
+  RadarShellAdd(&rstable,"mpincA",var_LONG,&mpincA);
+  RadarShellAdd(&rstable,"mppulA",var_LONG,&mppulA);
+  RadarShellAdd(&rstable,"mplgsA",var_LONG,&mplgsA);
+  RadarShellAdd(&rstable,"nrangA",var_LONG,&nrangA);
+  RadarShellAdd(&rstable,"frangA",var_LONG,&frangA);
+  RadarShellAdd(&rstable,"rsepA",var_LONG,&rsepA);
+  RadarShellAdd(&rstable,"bmnumA",var_LONG,&bmnumA);
+  RadarShellAdd(&rstable,"xcfA",var_LONG,&xcfA);
+  RadarShellAdd(&rstable,"tfreqA",var_LONG,&tfreqA);
+  RadarShellAdd(&rstable,"scanA",var_LONG,&scanA);
+  RadarShellAdd(&rstable,"mxpwrA",var_LONG,&mxpwrA);
+  RadarShellAdd(&rstable,"lvmaxA",var_LONG,&lvmaxA);
+  RadarShellAdd(&rstable,"rxriseA",var_LONG,&rxriseA);
+  RadarShellAdd(&rstable,"combfA",var_STRING,combfA);
+  RadarShellAdd(&rstable,"cpA",var_LONG,&cpA);
+
+  RadarShellAdd(&rstable,"txplB",var_LONG,&txplB);
+  RadarShellAdd(&rstable,"mpincB",var_LONG,&mpincB);
+  RadarShellAdd(&rstable,"mppulB",var_LONG,&mppulB);
+  RadarShellAdd(&rstable,"mplgsB",var_LONG,&mplgsB);
+  RadarShellAdd(&rstable,"nrangB",var_LONG,&nrangB);
+  RadarShellAdd(&rstable,"frangB",var_LONG,&frangB);
+  RadarShellAdd(&rstable,"rsepB",var_LONG,&rsepB);
+  RadarShellAdd(&rstable,"bmnumB",var_LONG,&bmnumB);
+  RadarShellAdd(&rstable,"xcfB",var_LONG,&xcfB);
+  RadarShellAdd(&rstable,"tfreqB",var_LONG,&tfreqB);
+  RadarShellAdd(&rstable,"scanB",var_LONG,&scanB);
+  RadarShellAdd(&rstable,"mxpwrB",var_LONG,&mxpwrB);
+  RadarShellAdd(&rstable,"lvmaxB",var_LONG,&lvmaxB);
+  RadarShellAdd(&rstable,"rxriseB",var_LONG,&rxriseB);
+  RadarShellAdd(&rstable,"combfB",var_STRING,combfB);
+  RadarShellAdd(&rstable,"cpB",var_LONG,&cpB);
+
+  OptionAdd(&opt, "ns",	'x', &ns);
+  OptionAdd(&opt, "fs",	'x', &fs);
+  OptionAdd(&opt, "e",	't', &ename);  
+  OptionAdd(&opt, "sc",	't', &sname);
+  OptionAdd(&opt, "intt",	'i', &intsc);
+  OptionAdd(&opt, "dfA",	'i', &dfrqA);
+  OptionAdd(&opt, "dfB",	'i', &dfrqB);
+  OptionAdd(&opt, "nfA",	'i', &nfrqA);
+  OptionAdd(&opt, "nfB",	'i', &nfrqB);
+  
+  OptionAdd(&opt, "offset",	'i',&stereo_offset);
+
+  OptionAdd(&opt, "frA",	'i', &frangA);
+  OptionAdd(&opt, "frB",	'i', &frangB);
+  OptionAdd(&opt, "rgA",	'i', &rsepA);
+  OptionAdd(&opt, "rgB",	'i', &rsepB);
+  OptionAdd(&opt, "lbA",	'i', &low_beam_A);
+  OptionAdd(&opt, "hbA",	'i', &high_beam_A);
+  OptionAdd(&opt, "lbB",	'i', &low_beam_B);
+  OptionAdd(&opt, "hbB",	'i', &high_beam_B);
+  OptionAdd(&opt, "sp",	'i', &scnsc);
+
+  OptionAdd(&opt, "cpidA", 'i', &cpidA);
+  OptionAdd(&opt, "cpidB", 'i', &cpidB);
+
+  /* set up remaining shell variables */
+
+  RadarShellAdd(&rstable, "dfA",var_LONG,&dfrqA);
+  RadarShellAdd(&rstable, "dfB",var_LONG,&dfrqB);
+  RadarShellAdd(&rstable, "nfA",var_LONG,&nfrqA);
+  RadarShellAdd(&rstable, "nfB",var_LONG,&nfrqB);
+
+  RadarShellAdd(&rstable, "offset",	var_LONG,&stereo_offset);
+ 
+  RadarShellAdd(&rstable, "low_beamA",	var_LONG,&low_beam_A);
+  RadarShellAdd(&rstable, "high_beamA",var_LONG,&high_beam_A);
+  RadarShellAdd(&rstable, "low_beamB",	var_LONG,&low_beam_B);
+  RadarShellAdd(&rstable, "high_beamB",var_LONG,&high_beam_B);
+  RadarShellAdd(&rstable, "scan_period",var_LONG,&scnsc);
+printf("** 2\n");
+
+  /* add new options - individual frequency bands */
+
+
+  /*
+	the beam lists now contain:
+	1) the number of beams in the beam lists
+	2) if no beam list or camp beams were specified = 0 -> 15
+	3) if high and low beams were specified			= low_beam -> high_beam
+  */
+   
+  sprintf(progname,"pcpstereoscan");
+printf("** 3\n");
+
+  OpsFitACFStart();
+
+  OpsSetupTask(tasklist);
+  for (n=0;n<tnum;n++) {
+    RMsgSndReset(tlist[n]);
+    RMsgSndOpen(tlist[n],strlen(cmdlne),cmdlne);     
+  }
+  /* set array of beams to match forward or backward scanning radar */
+  if(backward){
+	for(bmcnt=15;bmcnt>=0;bmcnt--){
+		bmnm[bmcnt]=15-bmcnt;
+	}
+  }
+  else{
+	for(bmcnt=0;bmcnt<=15;bmcnt++){
+		bmnm[bmcnt]=bmcnt;
+	}
+  }
+printf("** 4\n");
+
+  /*  Set up the array of frequency indices to use for sounding */
+  if(stid==0x09){
+	pcpfreqs[0]=20;
+	pcpfreqs[1]=22;
+	pcpfreqs[2]=23;
+	pcpfreqs[3]=26;
+	pcpfreqs[4]=30;
+	pcpfreqs[5]=32;
+	pcpfreqs[6]=33;
+	pcpfreqs[7]=35;
+   }else if (stid==0x10){
+	pcpfreqs[0]=0;
+	pcpfreqs[1]=1;
+	pcpfreqs[2]=2;
+	pcpfreqs[3]=4;
+	pcpfreqs[4]=6;
+	pcpfreqs[5]=7;
+	pcpfreqs[6]=8;
+	pcpfreqs[7]=10;
+   }
+printf("** 5\n");
+
+   /* set the number of range gates to 225 */
+   nrangA=225;
+   nrangB=225;
+   /* set range seperation to 15km */
+   rsepA=15;
+   rsepB=15;
+
+  /* scan loop */
+  do {
+	/* 3 second integrations during the scan */
+  	intsc=3;
+  	intus=0;
+printf("** 6\n");
+    	if (SiteStartScan()==0) continue;
+    	if (OpsReOpen(2,0,0) !=0) {
+      		ErrLog(errlog,progname,"Opening new files.");
+printf("** 7\n");
+      		for (n=0;n<tnum;n++) {
+        		RMsgSndClose(tlist[n]);
+        		RMsgSndOpen(tlist[n],strlen(cmdlne),cmdlne);     
+printf("** 8\n");
+      		}
+    	}
+	/* set scan parameter to match forward or backward scanning radar */
+    	scanA=scanB=1; 
+printf("** 9\n");
+    	ErrLog(errlog,progname,"Starting scan.");
+
+	/* Scan over all 16 beams */
+    	for (bmcnt=0;bmcnt<=15;bmcnt++) {
+      		bmnumA=bmnm[bmcnt];
+      		bmnumB=bmnm[bmcnt];
+
+      		TimeReadClock(&yr,&mo,&dy,&hr,&mt,&sc,&us);
+printf("** 10\n");
+       		if (OpsDayNight()==1) {
+       			stfrqA=usfreq[dfrqA];
+       			frqrngA=ufreq_range[dfrqA];
+       		} else {
+       			stfrqA=usfreq[nfrqA];
+       			frqrngA=ufreq_range[nfrqA];
+       		} 
+
+      		if (OpsDayNight()==1) {
+       			stfrqB=usfreq[dfrqB];
+       			frqrngB=ufreq_range[dfrqB];
+       		} else {
+       			stfrqB=usfreq[nfrqB]; 	//jth change 
+//       			tfrqB=usfreq[nfrqB]; 	//jth change 
+       			frqrngB=ufreq_range[nfrqB];
+       		} 
+printf("** 11\n");
+      		SiteSetChannel(CHN_B);
+      		SiteSetBeam(bmnumB);
+      		SiteSetChannel(CHN_A);
+      		SiteSetBeam(bmnumA);
+printf("** 11a\n"); 
+      		SiteSetIntt(intsc,intus);
+printf("** 11b\n");
+printf("**stfrqA=%d, frqrngA=%d, stfrqB=%d, frqrngB=%d\n",stfrqA, frqrngA, stfrqB, frqrngB); 
+      		if (SiteFCLRS(stfrqA,stfrqA+frqrngA,stfrqB,
+                    stfrqB+frqrngB)==FREQ_LOCAL)
+        		ErrLog(errlog,progname,"Frequency Synthesizer in local mode.");
+printf("** 12\n");
+      		if (tfreqA==-1) tfreqA=ftable->dfrq;
+      		if (tfreqB==-1) tfreqB=ftable->dfrq;
+printf("** 13\n");
+      		sprintf(logtxt,"Channel A Transmitting on: %d (Noise=%g)",tfreqA,noiseA);
+      		ErrLog(errlog,progname,logtxt);
+
+      		sprintf(logtxt,"Channel B Transmitting on: %d (Noise=%g)",tfreqB,noiseB);
+      		ErrLog(errlog,progname,logtxt);
+
+      		SiteSetChannel(CHN_A);
+      		SiteSetFreq(tfreqA);
+      		SiteSetChannel(CHN_B);
+      		SiteSetFreq(tfreqB);
+
+	  	sprintf(logtxt,"Integrating:%2d,%2d intt:%d (%02d:%02d:%02d) %5d  %5d - %s  %d\n",
+		      	bmnumA, bmnumB, intsc, hr, mt, 
+              		sc, tfreqA, tfreqB,  
+              		OpsDayNight() ? "day" : "night", abs(tfreqA - tfreqB));
+      		ErrLog(errlog,progname,logtxt);
+      		u_read_uconts();
+
+      		txplA = (rsepA * 20) / 3;
+      		txplB = (rsepB * 20) / 3;
+      		tsgidA=SiteTimeSeqS(0,ptab);
+      		tsgidB=SiteTimeSeqS(1,ptab);
+
+      		SiteIntegrateS(lags,lags);   
+
+      		if (naveA<0) {
+        		sprintf(logtxt,"Integration A failed:%d",naveA);
+        		ErrLog(errlog,progname,logtxt); 
+        		continue;
+      		}
+      		if (naveB<0) {
+        		sprintf(logtxt,"Integration B failed:%d",naveB);
+        		ErrLog(errlog,progname,logtxt); 
+        		continue;
+      		}
+
+      		sprintf(logtxt,"Number of sequences: %d %d",naveA,naveB);
+      		ErrLog(errlog,progname,logtxt);
+
+      		OpsBuildRawS(0,&prmA,&rawA,ptab,lags);
+      		OpsBuildRawS(1,&prmB,&rawB,ptab,lags);
+
+      		FitACF(&prmA,&rawA,&fblk,&fitA);
+      		FitACF(&prmB,&rawB,&fblk,&fitB);
+
+      		ErrLog(errlog,progname,"Sending messages."); 
+      		msg.num=0;
+      		msg.tsize=0;
+      		RMsgSndAdd(&msg,sizeof(struct RadarParm),(unsigned char *) &prmA,
+			PRM_TYPE,0); 
+      		RMsgSndAdd(&msg,sizeof(struct RawData),(unsigned char *) &rawA,
+			RAW_TYPE,0);    
+      		RMsgSndAdd(&msg,sizeof(struct FitData),(unsigned char *) &fitA,
+			FIT_TYPE,0);
+      		RMsgSndAdd(&msg,strlen(progname)+1,progname,
+			NME_TYPE,0);   
+      		RMsgSndAdd(&msg,sizeof(struct RadarParm),(unsigned char *) &prmB,
+			PRM_TYPE,1); 
+      		RMsgSndAdd(&msg,sizeof(struct RawData),(unsigned char *) &rawB,
+			RAW_TYPE,1);    
+      		RMsgSndAdd(&msg,sizeof(struct FitData),(unsigned char *) &fitB,
+			FIT_TYPE,1);
+      		RMsgSndAdd(&msg,strlen(progname)+1,progname,
+			NME_TYPE,1);   
+      		for (n=0;n<tnum;n++) RMsgSndSend(tlist[n],&msg); 
+  
+      		ErrLog(errlog,progname,"Polling for exit."); 
+      		exitpoll=RadarShell(sid,&rstable);
+
+	  	/* Calculate delay offsets if stereo offset has been changed
+         		If stereo_offset is +ve A is later than B
+       		*/
+
+	  	if (stereo_offset > 0) {
+	    		delays[1] = 0;
+			delays[0] = stereo_offset / 10; /* stereo_offset is in usec */
+ 	  	} else {
+			delays[0] = 0;
+			delays[1] = (stereo_offset / 10) * (-1); /* stereo_offset is in usec */
+	  	}
+
+	  	if (exitpoll !=0) break;
+
+	  	scanA = 0;
+	  	scanB = 0;
+
+   	} 
+    
+	/* increment individual frequency band index. Doesn't matter whether
+	   individual frequency bands are being used for this channel or not.
+     	*/
+	/************  Sounding at end of scan ******************************/
+	
+	scanA=-2;
+	scanB=-2;
+        /* set sounding integration time to 1 second */
+  	intsc=1;
+  	intus=0;
+	/* step through array of 8 frequencies */
+	for(pcpcnt=0;pcpcnt<PCPFNUM;pcpcnt++){
+		/* use fixed beam for this sounding */
+      		bmnumA=PCPBEAM;
+      		bmnumB=PCPBEAM;
+      		TimeReadClock(&yr,&mo,&dy,&hr,&mt,&sc,&us);
+
+       		stfrqA=usfreq[pcpfreqs[pcpcnt]];
+       		frqrngA=ufreq_range[pcpfreqs[pcpcnt]];
+
+      		SiteSetChannel(CHN_B);
+      		SiteSetBeam(bmnumB);
+      		SiteSetChannel(CHN_A);
+      		SiteSetBeam(bmnumA);
+ 
+      		SiteSetIntt(intsc,intus);
+      		if (SiteFCLRS(stfrqA,stfrqA+frqrngA,stfrqB,
+                    stfrqB+frqrngB)==FREQ_LOCAL)
+        		ErrLog(errlog,progname,"Frequency Synthesizer in local mode.");
+
+      		if (tfreqA==-1) tfreqA=ftable->dfrq;
+      		if (tfreqB==-1) tfreqB=ftable->dfrq;
+
+      		sprintf(logtxt,"Channel A Transmitting on: %d (Noise=%g)",tfreqA,noiseA);
+      		ErrLog(errlog,progname,logtxt);
+
+      		sprintf(logtxt,"Channel B Transmitting on: %d (Noise=%g)",tfreqB,noiseB);
+      		ErrLog(errlog,progname,logtxt);
+
+      		SiteSetChannel(CHN_A);
+      		SiteSetFreq(tfreqA);
+      		SiteSetChannel(CHN_B);
+      		SiteSetFreq(tfreqB);
+	  	sprintf(logtxt,"Integrating:%2d,%2d intt:%d (%02d:%02d:%02d) %5d  %5d - %s  %d\n",
+		      	bmnumA, bmnumB, intsc, hr, mt, 
+              		sc, tfreqA, tfreqB,  
+              		OpsDayNight() ? "day" : "night", abs(tfreqA - tfreqB));
+      		ErrLog(errlog,progname,logtxt);
+      		u_read_uconts();
+
+      		txplA = (rsepA * 20) / 3;
+      		txplB = (rsepB * 20) / 3;
+      		tsgidA=SiteTimeSeqS(0,ptab);
+      		tsgidB=SiteTimeSeqS(1,ptab);
+
+      		SiteIntegrateS(lags,lags);   
+
+      		if (naveA<0) {
+        		sprintf(logtxt,"Integration A failed:%d",naveA);
+        		ErrLog(errlog,progname,logtxt); 
+        		continue;
+      		}
+      		if (naveB<0) {
+        		sprintf(logtxt,"Integration B failed:%d",naveB);
+        		ErrLog(errlog,progname,logtxt); 
+        		continue;
+      		}
+      		sprintf(logtxt,"Number of sequences: %d %d",naveA,naveB);
+      		ErrLog(errlog,progname,logtxt);
+
+      		OpsBuildRawS(0,&prmA,&rawA,ptab,lags);
+      		OpsBuildRawS(1,&prmB,&rawB,ptab,lags);
+
+      		FitACF(&prmA,&rawA,&fblk,&fitA);
+      		FitACF(&prmB,&rawB,&fblk,&fitB);
+
+      		ErrLog(errlog,progname,"Sending messages."); 
+      		msg.num=0;
+      		msg.tsize=0;
+      		RMsgSndAdd(&msg,sizeof(struct RadarParm),(unsigned char *) &prmA,
+			PRM_TYPE,0); 
+      		RMsgSndAdd(&msg,sizeof(struct RawData),(unsigned char *) &rawA,
+			RAW_TYPE,0);    
+      		RMsgSndAdd(&msg,sizeof(struct FitData),(unsigned char *) &fitA,
+			FIT_TYPE,0);
+      		RMsgSndAdd(&msg,strlen(progname)+1,progname,
+			NME_TYPE,0);   
+      		RMsgSndAdd(&msg,sizeof(struct RadarParm),(unsigned char *) &prmB,
+			PRM_TYPE,1); 
+      		RMsgSndAdd(&msg,sizeof(struct RawData),(unsigned char *) &rawB,
+			RAW_TYPE,1);    
+      		RMsgSndAdd(&msg,sizeof(struct FitData),(unsigned char *) &fitB,
+			FIT_TYPE,1);
+      		RMsgSndAdd(&msg,strlen(progname)+1,progname,
+			NME_TYPE,1);   
+      		for (n=0;n<tnum;n++) RMsgSndSend(tlist[n],&msg); 
+      		ErrLog(errlog,progname,"Polling for exit."); 
+      		exitpoll=RadarShell(sid,&rstable);
+
+	  	/* Calculate delay offsets if stereo offset has been changed
+         		If stereo_offset is +ve A is later than B
+       		*/
+
+	  	if (stereo_offset > 0) {
+	    		delays[1] = 0;
+			delays[0] = stereo_offset / 10; /* stereo_offset is in usec */
+ 	  	} else {
+			delays[0] = 0;
+			delays[1] = (stereo_offset / 10) * (-1); /* stereo_offset is in usec */
+	  	}
+
+	  	if (exitpoll !=0) break;
+
+
+
+	}
+	scanA = 0;
+	scanB = 0;
+
+	/************  Sounding at end of scan ******************************/
+
+    	ErrLog(errlog,progname,"Waiting for scan boundary."); 
+    	if ((scnsc !=0) || (scnus !=0)) {
+      		if (exitpoll==0) OpsWaitBoundary(scnsc,scnus);
+    	}
+  } while (exitpoll==0);
+  SiteEnd();
+  for (n=0;n<tnum;n++) RMsgSndClose(tlist[n]);
+  ErrLog(errlog,progname,"Ending program.");
+  RShellTerminate(sid);
+  return 0;   
+} 
+ 
+
+/***************************************************************************/
+
+/* Sets up the licenced frequency bands for Iceland & finland */
+
+void u_init_freq_bands() {
+
+/* start freq of each band */
+
+   /* Finland */
+
+   usfreq[0] = 8305;
+   usfreq[1] = 8965;
+   usfreq[2] = 9900;
+   usfreq[3] = 11075;
+   usfreq[4] = 11550;
+   usfreq[5] = 12370;
+   usfreq[6] = 13200;
+   usfreq[7] = 15010;
+   usfreq[8] = 16210;
+   usfreq[9] = 16555;
+   usfreq[10] = 17970;
+   usfreq[11] = 18850;
+   usfreq[12] = 19415;
+   usfreq[13] = 19705;
+   usfreq[14] = 19800;
+
+   /* Iceland */
+
+   usfreq[20] = 8000;
+   usfreq[21] = 8430;
+   usfreq[22] = 8985;
+   usfreq[23] = 10155;
+   usfreq[24] = 10655;
+   usfreq[25] = 11290;
+   usfreq[26] = 11475;
+   usfreq[27] = 12105;
+   usfreq[28] = 12305;
+   usfreq[29] = 12590;
+   usfreq[30] = 13360;
+   usfreq[31] = 13875;
+   usfreq[32] = 14400;
+   usfreq[33] = 15805;
+   usfreq[34] = 16500;
+   usfreq[35] = 16820;
+   usfreq[36] = 18175;
+   usfreq[37] = 18835;
+   usfreq[38] = 19910;
+   usfreq[39] = 10155;
+
+   /* width of each band */
+
+   /* Finland */
+
+   ufreq_range[0] = 30;
+   ufreq_range[1] = 75;
+   ufreq_range[2] = 85;
+   ufreq_range[3] = 200;
+   ufreq_range[4] = 50;
+   ufreq_range[5] = 45;
+   ufreq_range[6] = 60;
+   ufreq_range[7] = 70;
+   ufreq_range[8] = 150;
+   ufreq_range[9] = 60;
+   ufreq_range[10] = 80;
+   ufreq_range[11] = 15;
+   ufreq_range[12] = 265;
+   ufreq_range[13] = 50;
+   ufreq_range[14] = 190; 
+
+   /* Iceland */
+
+   ufreq_range[20] = 195;
+   ufreq_range[21] = 420;
+   ufreq_range[22] = 410;
+   ufreq_range[23] = 500;
+   ufreq_range[24] = 520;
+   ufreq_range[25] = 160;
+   ufreq_range[26] = 120;
+   ufreq_range[27] = 130;
+   ufreq_range[28] = 205;
+   ufreq_range[29] = 690;
+   ufreq_range[30] = 205;
+   ufreq_range[31] = 120;
+   ufreq_range[32] = 615;
+   ufreq_range[33] = 560;
+   ufreq_range[34] = 185;
+   ufreq_range[35] = 655;
+   ufreq_range[36] = 595;
+   ufreq_range[37] = 50;
+   ufreq_range[38] = 90;
+   ufreq_range[39] = 1020;
+}
+
+/* Sends a proxy message to the microcontroller monitoring 
+   task every beam.
+*/
+
+void u_read_uconts() {
+  if (uucont_proxy != 0) Trigger(uucont_proxy);
+}
+

--- a/qnx4/sd_leicester/han/pcpstereoscan.1.02/pcpstereoscan.c.orig
+++ b/qnx4/sd_leicester/han/pcpstereoscan.1.02/pcpstereoscan.c.orig
@@ -1,0 +1,864 @@
+/* stereoscan.c
+   ============
+   Author: R.J.Barnes
+*/
+
+/*
+ Copyright 2004 The Johns Hopkins University/Applied Physics Laboratory.
+ All rights reserved.
+ 
+ This material may be used, modified, or reproduced by or for the U.S.
+ Government pursuant to the license rights granted under the clauses at DFARS
+ 252.227-7013/7014.
+ 
+ For any other permissions, please contact the Space Department
+ Program Office at JHU/APL.
+ 
+ This Distribution and Disclaimer Statement must be included in all copies of
+ "Radar Operating System - Control Programs" (hereinafter "the Program").
+ 
+ The Program was developed at The Johns Hopkins University/Applied Physics
+ Laboratory (JHU/APL) which is the author thereof under the "work made for
+ hire" provisions of the copyright law.  
+ 
+ JHU/APL assumes no obligation to provide support of any kind with regard to
+ the Program.  This includes no obligation to provide assistance in using the
+ Program or to provide updated versions of the Program.
+ 
+ THE PROGRAM AND ITS DOCUMENTATION ARE PROVIDED AS IS AND WITHOUT ANY EXPRESS
+ OR IMPLIED WARRANTIES WHATSOEVER.  ALL WARRANTIES INCLUDING, BUT NOT LIMITED
+ TO, PERFORMANCE, MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE ARE
+ HEREBY DISCLAIMED.  YOU ASSUME THE ENTIRE RISK AND LIABILITY OF USING THE
+ PROGRAM TO INCLUDE USE IN COMPLIANCE WITH ANY THIRD PARTY RIGHTS.  YOU ARE
+ ADVISED TO TEST THE PROGRAM THOROUGHLY BEFORE RELYING ON IT.  IN NO EVENT
+ SHALL JHU/APL BE LIABLE FOR ANY DAMAGES WHATSOEVER, INCLUDING, WITHOUT
+ LIMITATION, ANY LOST PROFITS, LOST SAVINGS OR OTHER INCIDENTAL OR
+ CONSEQUENTIAL DAMAGES, ARISING OUT OF THE USE OR INABILITY TO USE THE
+ PROGRAM."
+ 
+ 
+ 
+ 
+ 
+  
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/types.h>
+#include <sys/proxy.h>
+#include <sys/kernel.h>
+#include <string.h>
+#include <time.h>
+#include "rtypes.h"
+#include "option.h"
+#include "rtime.h"
+#include "limit.h"
+#include "radar.h"
+#include "rprm.h"
+#include "rawdata.h"
+#include "fitblk.h"
+#include "fitdata.h"
+#include "fitacf.h"
+
+#include "taskid.h"
+#include "errlog.h"
+#include "freq.h"
+#include "rmsg.h"
+#include "radarshell.h"
+#include "rmsgsnd.h"
+#include "tsg.h"
+#include "tsgtable.h"
+#include "maketsg.h"
+#include "global.h"
+#include "globals.h"
+#include "setup.h"
+#include "reopen.h"
+#include "tmseq.h"
+#include "raws.h"
+#include "sync.h"
+#include "interface.h"
+#include "hdw.h"
+
+/*
+ $Log: pcpstereoscan.c,v $
+ Revision 1.2  2006/07/12 15:51:43  code
+ Added call to set up command line and limited data written to rawacf and fitacf.
+
+ Revision 1.1  2006/03/30 11:19:18  barnes
+ Initial revision
+ 
+*/
+
+/*
+	Modified 10/12/2001 PH
+
+	Added bnA and bnB frequency band options to cycle through frequency
+	bands during each scan. No check is made for invalid band numbers.
+	A band number of -1 is ignored. Bands can be added/removed at any
+	time using radar_shell, changes won't take effect until the end of
+	the current scan. If no band numbers are specified, normal day/night
+	frequencies are used.
+
+	Frequency bands can also be specified for campA and campB modes.
+
+	Extra options can be placed in a separate schedule file. The file
+	name should be the last argument in the schedule argument list and
+	should include the full path.
+
+	Modified 16/01/02 PH
+
+	Fixed synchronisation bug. The code wasn't subtracting the time taken
+	for a clear frequency search from the beam integration time, resulting
+	in an extended beam dwell time and a sweep lasting for more than 60 s
+	for fast stereo and 120 s for slow stereo 7 s integration.
+
+	Standard slow stereo (normal stereo) is now 7 seconds (by Mark Lester).
+
+	Modified 30/01/02 PH
+
+	added -cts? options that pre-set other options
+
+			dwell	chan A	cpidA	chan B	cpidB	Ice/Fin	offset	range
+			------	------	------	------	------	------- ------	-----
+	cts2 -    7		normal	 152	 tbj	-26002	 5 / 9	 +400	 45
+	cts4 -	  7		normal	 152	normal	-26004	 5 / 9	 +400	 45
+	cts6 -	  7		normal	 152	1 camp	-26006	 5 / 9	 +400	 45
+	cts8 -	  7		normal	 152	2 camp	-26008	 5 / 9	 +400	 45
+
+	cts3 -	  3		normal	 153	 tbj	-26003	 5 / 9	 +400	 45
+	cts5 -	  3		normal	 153	normal	-26005	 5 / 9	 +400	 45
+	cts7 -	  3		normal	 153	1 camp	-26007	 5 / 9	 +400	 45
+	cts9 -	  3		normal	 153	2 camp	-26009	 5 / 9	 +400	 45
+
+	Single camp beams are hard coded to the standard Finland beam 9 and
+	Iceland beam 5.
+
+	Double camp beams are the same for both radars and defined as
+	DOUBLE_CAMP_LOW and DOUBLE_CAMP_HIGH.
+
+	range gates and first range are let to the default settings of 45km
+	and 180km respectively.
+
+	specifying any cts option will override low and high beam, offset, cpIDs,
+	integration time and scan boundary. tbj mode overrides frequencies.
+
+	Modified 05/04/02 PH
+
+	Uses the new stereo aware version of fitacf (1.06).
+
+	Modified 30/04/2002 PH
+
+	Added cpidA and cpidB to set the cpid. This option overrides any
+	previously defined cpid.
+
+	Added bmnA and bmnB to cycle through beams numbers on both channels.
+	To specify double camp beams use -bm0B 5 -bm1B 9
+	To specify single camp beams use -bm0B 5
+	The same beam number can be specified more than once.
+	The number of beams in the channel A beam list determines the number of
+	beams per scan. This is important if you are also using frequency lists.
+
+	cts 2, 3, 4, 5 beams patterns can be changed with bm*A and bm*B options.
+
+	Modified 25/09/02 PH
+
+	Changed so that the B channel frequency band changes at the end of the
+	channel B scan, so that it is independent of the number of beams on
+	channel A.
+
+  Modified 7th Dec 2001 to add camp beam flags
+  Modified 23 Nov 2001 to add new -ns and -fs flags and changed some defaults
+  Modified 10th Aug to account for backwards scanning radars
+  Modified 8th Aug fitacf_s
+  Julian modified version. March 2001
+
+*/
+
+/* set CPIDs for this experiment, 9212 is CPID provided by UAF for polar cap patch experiment
+   -26999 is dummy CPID for the non-existent channelB */
+#define CPID_A 9212
+#define CPID_B -26999
+
+
+#define INTT      3
+#define RSEP_A 15
+#define RSEP_B 15
+#define FRANG_A 180
+#define FRANG_B 180
+
+
+#define LOW_BEAM_A   0
+#define HIGH_BEAM_A  15
+#define LOW_BEAM_B   0
+#define HIGH_BEAM_B  15
+
+#define SINGLE_CAMP_BEAM_PYK 5
+#define SINGLE_CAMP_BEAM_HAN 9
+
+
+#define DOUBLE_CAMP_LOW 5
+#define DOUBLE_CAMP_HIGH 9
+
+#define UCONT_NAME "ucont_moni"
+
+#define CHN_A 0
+#define CHN_B 1
+
+#define NUMBANDS 10
+#define NUMBEAMS 16
+
+
+#define SCHEDULER "schedule"
+#define ERRLOG "errlog"
+
+#define CONTROL_NAME "control_program"
+#define TASK_NAMES "echo_data","rawacfwrite","fitacfwrite"
+
+#define PCPBEAM 9
+#define PCPFNUM 8
+int pcpfreqs[PCPFNUM]; 
+int pcpcnt;
+
+void u_read_uconts(void);
+void u_init_freq_bands(void);
+
+char cmdlne[1024];
+char progid[80]={"$Id: pcpstereoscan.c,v 1.2 2011/12/13 15:51:43 code Exp $"};
+char progname[256];
+struct TaskID *errlog;
+
+int usfreq[42];
+int ufreq_range[42];
+
+pid_t uucont_proxy;
+
+int low_beam_A=LOW_BEAM_A;
+int high_beam_A=HIGH_BEAM_A;
+int low_beam_B=LOW_BEAM_B;
+int high_beam_B=HIGH_BEAM_B;
+
+
+
+
+char *tasklist[]=
+ { TASK_NAMES,
+  0};
+
+int arg=0;
+struct OptionData opt;
+      
+int main(int argc,char *argv[]) {
+
+  int ptab[7] = {0,9,12,20,22,26,27};
+
+  int lags[LAG_SIZE][2] = {
+    { 0, 0},		/*  0 */
+    {26,27},		/*  1 */
+    {20,22},		/*  2 */
+    {9,12},		/*  3 */
+    {22,26},		/*  4 */
+    {22,27},		/*  5 */
+
+    {20,26},		/*  7 */
+    {20,27},		/*  8 */
+    {0,9},		/*  9 */
+    {12,22},		/* 10 */
+    {9,20},		/* 11 */
+    {0,12},	  	    /* 12 */
+    {9,22},		/* 13 */
+    {12,26},		/* 14 */
+    {12,27},		/* 15 */
+    {9,26},		/* 16 */
+    {9,27},		/* 17 */
+    {27,27}};		/* alternate lag-0  */
+
+
+  char *sname=NULL;
+  char *ename=NULL;
+  char *sdname={SCHEDULER};
+  char *edname={ERRLOG};
+  char logtxt[1024];
+
+  char a[10];
+
+  int n,i;
+  pid_t sid;
+  int exitpoll=0;
+ 
+  int scnsc=0;
+  int scnus=0;
+ 
+  unsigned char ns=0;
+  unsigned char fs=0;
+
+  int stereo_offset=400; /* channel A delayed by this 
+                            number of microseconds */
+
+
+  int ifreqsA[NUMBANDS],ifreqsB[NUMBANDS];
+
+  int day_nightA=1;
+  int day_nightB=1;
+
+  int numfreqbandsA;
+  int numfreqbandsB;
+
+  int ifreqsA_index=0; 
+  int ifreqsB_index=0;
+  
+  int ifreqsAband;
+  int ifreqsBband;
+
+  int sbm, ebm, bmnm[16], bmcnt;
+
+  int numbeamsA,numbeamsB;
+
+  unsigned char cts2=0,cts4=0,cts6=0,cts8=0;
+  unsigned char cts3=0,cts5=0,cts7=0,cts9=0;
+  
+  int cpidA=0,cpidB=0;
+
+  xcfA=xcfB=1;
+ 
+  cpA=CPID_A;
+  cpB=CPID_B;
+
+  SiteStart();
+ 
+  intsc=INTT;
+  intus=0;
+ 
+  maxattenA=maxattenB=7;
+
+  if ((uucont_proxy=SiteInitProxy(UCONT_NAME))==-1) {
+    perror("cannot attach proxy");
+  }
+ 
+  u_init_freq_bands();
+  
+  strcpy(cmdlne,argv[0]);
+  for (n=1;n<argc;n++) {
+    strcat(cmdlne," ");
+    strcat(cmdlne,argv[n]);
+  } 
+
+  strncpy(combf,progid,80);   
+  OpsSetupCommand(argc,argv);
+  OpsSetupRadar();
+  OpsSetupShell();
+
+  RadarShellAdd(&rstable,"intt",var_LONG,&intsc);
+  RadarShellAdd(&rstable,"inttsc",var_LONG,&intsc);
+  RadarShellAdd(&rstable,"inttus",var_LONG,&intus);
+
+  RadarShellAdd(&rstable,"txplA",var_LONG,&txplA);
+  RadarShellAdd(&rstable,"mpincA",var_LONG,&mpincA);
+  RadarShellAdd(&rstable,"mppulA",var_LONG,&mppulA);
+  RadarShellAdd(&rstable,"mplgsA",var_LONG,&mplgsA);
+  RadarShellAdd(&rstable,"nrangA",var_LONG,&nrangA);
+  RadarShellAdd(&rstable,"frangA",var_LONG,&frangA);
+  RadarShellAdd(&rstable,"rsepA",var_LONG,&rsepA);
+  RadarShellAdd(&rstable,"bmnumA",var_LONG,&bmnumA);
+  RadarShellAdd(&rstable,"xcfA",var_LONG,&xcfA);
+  RadarShellAdd(&rstable,"tfreqA",var_LONG,&tfreqA);
+  RadarShellAdd(&rstable,"scanA",var_LONG,&scanA);
+  RadarShellAdd(&rstable,"mxpwrA",var_LONG,&mxpwrA);
+  RadarShellAdd(&rstable,"lvmaxA",var_LONG,&lvmaxA);
+  RadarShellAdd(&rstable,"rxriseA",var_LONG,&rxriseA);
+  RadarShellAdd(&rstable,"combfA",var_STRING,combfA);
+  RadarShellAdd(&rstable,"cpA",var_LONG,&cpA);
+
+  RadarShellAdd(&rstable,"txplB",var_LONG,&txplB);
+  RadarShellAdd(&rstable,"mpincB",var_LONG,&mpincB);
+  RadarShellAdd(&rstable,"mppulB",var_LONG,&mppulB);
+  RadarShellAdd(&rstable,"mplgsB",var_LONG,&mplgsB);
+  RadarShellAdd(&rstable,"nrangB",var_LONG,&nrangB);
+  RadarShellAdd(&rstable,"frangB",var_LONG,&frangB);
+  RadarShellAdd(&rstable,"rsepB",var_LONG,&rsepB);
+  RadarShellAdd(&rstable,"bmnumB",var_LONG,&bmnumB);
+  RadarShellAdd(&rstable,"xcfB",var_LONG,&xcfB);
+  RadarShellAdd(&rstable,"tfreqB",var_LONG,&tfreqB);
+  RadarShellAdd(&rstable,"scanB",var_LONG,&scanB);
+  RadarShellAdd(&rstable,"mxpwrB",var_LONG,&mxpwrB);
+  RadarShellAdd(&rstable,"lvmaxB",var_LONG,&lvmaxB);
+  RadarShellAdd(&rstable,"rxriseB",var_LONG,&rxriseB);
+  RadarShellAdd(&rstable,"combfB",var_STRING,combfB);
+  RadarShellAdd(&rstable,"cpB",var_LONG,&cpB);
+
+  OptionAdd(&opt, "ns",	'x', &ns);
+  OptionAdd(&opt, "fs",	'x', &fs);
+  OptionAdd(&opt, "e",	't', &ename);  
+  OptionAdd(&opt, "sc",	't', &sname);
+  OptionAdd(&opt, "intt",	'i', &intsc);
+  OptionAdd(&opt, "dfA",	'i', &dfrqA);
+  OptionAdd(&opt, "dfB",	'i', &dfrqB);
+  OptionAdd(&opt, "nfA",	'i', &nfrqA);
+  OptionAdd(&opt, "nfB",	'i', &nfrqB);
+  
+  OptionAdd(&opt, "offset",	'i',&stereo_offset);
+
+  OptionAdd(&opt, "frA",	'i', &frangA);
+  OptionAdd(&opt, "frB",	'i', &frangB);
+  OptionAdd(&opt, "rgA",	'i', &rsepA);
+  OptionAdd(&opt, "rgB",	'i', &rsepB);
+  OptionAdd(&opt, "lbA",	'i', &low_beam_A);
+  OptionAdd(&opt, "hbA",	'i', &high_beam_A);
+  OptionAdd(&opt, "lbB",	'i', &low_beam_B);
+  OptionAdd(&opt, "hbB",	'i', &high_beam_B);
+  OptionAdd(&opt, "sp",	'i', &scnsc);
+
+  OptionAdd(&opt, "cpidA", 'i', &cpidA);
+  OptionAdd(&opt, "cpidB", 'i', &cpidB);
+
+  /* set up remaining shell variables */
+
+  RadarShellAdd(&rstable, "dfA",var_LONG,&dfrqA);
+  RadarShellAdd(&rstable, "dfB",var_LONG,&dfrqB);
+  RadarShellAdd(&rstable, "nfA",var_LONG,&nfrqA);
+  RadarShellAdd(&rstable, "nfB",var_LONG,&nfrqB);
+
+  RadarShellAdd(&rstable, "offset",	var_LONG,&stereo_offset);
+ 
+  RadarShellAdd(&rstable, "low_beamA",	var_LONG,&low_beam_A);
+  RadarShellAdd(&rstable, "high_beamA",var_LONG,&high_beam_A);
+  RadarShellAdd(&rstable, "low_beamB",	var_LONG,&low_beam_B);
+  RadarShellAdd(&rstable, "high_beamB",var_LONG,&high_beam_B);
+  RadarShellAdd(&rstable, "scan_period",var_LONG,&scnsc);
+
+  /* add new options - individual frequency bands */
+
+
+  /*
+	the beam lists now contain:
+	1) the number of beams in the beam lists
+	2) if no beam list or camp beams were specified = 0 -> 15
+	3) if high and low beams were specified			= low_beam -> high_beam
+  */
+   
+  sprintf(progname,"pcpstereoscan");
+
+  OpsFitACFStart();
+
+  OpsSetupTask(tasklist);
+  for (n=0;n<tnum;n++) {
+    RMsgSndReset(tlist[n]);
+    RMsgSndOpen(tlist[n],strlen(cmdlne),cmdlne);     
+  }
+  /* set array of beams to match forward or backward scanning radar */
+  if(backward){
+	for(bmcnt=15;bmcnt>=0;bmcnt--){
+		bmnm[bmcnt]=15-bmcnt;
+	}
+  }
+  else{
+	for(bmcnt=0;bmcnt<=15;bmcnt++){
+		bmnm[bmcnt]=bmcnt;
+	}
+  }
+  /*  Set up the array of frequency indices to use for sounding */
+  if(stid==0x09){
+	pcpfreqs[0]=20;
+	pcpfreqs[1]=22;
+	pcpfreqs[2]=23;
+	pcpfreqs[3]=26;
+	pcpfreqs[4]=30;
+	pcpfreqs[5]=32;
+	pcpfreqs[6]=33;
+	pcpfreqs[7]=35;
+   }else if (stid==0x10){
+	pcpfreqs[0]=0;
+	pcpfreqs[1]=1;
+	pcpfreqs[2]=2;
+	pcpfreqs[3]=4;
+	pcpfreqs[4]=6;
+	pcpfreqs[5]=7;
+	pcpfreqs[6]=8;
+	pcpfreqs[7]=10;
+   }
+   /* set the number of range gates to 225 */
+   nrangA=225;
+   nrangB=225;
+   /* set range seperation to 15km */
+   rsepA=15;
+   rsepB=15;
+
+  /* scan loop */
+  do {
+	/* 3 second integrations during the scan */
+  	intsc=3;
+  	intus=0;
+    	if (SiteStartScan()==0) continue;
+    	if (OpsReOpen(2,0,0) !=0) {
+      		ErrLog(errlog,progname,"Opening new files.");
+      		for (n=0;n<tnum;n++) {
+        		RMsgSndClose(tlist[n]);
+        		RMsgSndOpen(tlist[n],strlen(cmdlne),cmdlne);     
+      		}
+    	}
+	/* set scan parameter to match forward or backward scanning radar */
+    	scanA=scanB=1; 
+
+    	ErrLog(errlog,progname,"Starting scan.");
+
+	/* Scan over all 16 beams */
+    	for (bmcnt=0;bmcnt<=15;bmcnt++) {
+      		bmnumA=bmnm[bmcnt];
+      		bmnumB=bmnm[bmcnt];
+
+      		TimeReadClock(&yr,&mo,&dy,&hr,&mt,&sc,&us);
+
+       		if (OpsDayNight()==1) {
+       			stfrqA=usfreq[dfrqA];
+       			frqrngA=ufreq_range[dfrqA];
+       		} else {
+       			stfrqA=usfreq[nfrqA];
+       			frqrngA=ufreq_range[nfrqA];
+       		} 
+
+      		if (OpsDayNight()==1) {
+       			stfrqB=usfreq[dfrqB];
+       			frqrngB=ufreq_range[dfrqB];
+       		} else {
+       			stfrqB=usfreq[nfrqB]; 	//jth change 
+//       			tfrqB=usfreq[nfrqB]; 	//jth change 
+       			frqrngB=ufreq_range[nfrqB];
+       		} 
+
+      		SiteSetChannel(CHN_B);
+      		SiteSetBeam(bmnumB);
+      		SiteSetChannel(CHN_A);
+      		SiteSetBeam(bmnumA);
+ 
+      		SiteSetIntt(intsc,intus);
+ 
+      		if (SiteFCLRS(stfrqA,stfrqA+frqrngA,stfrqB,
+                    stfrqB+frqrngB)==FREQ_LOCAL)
+        		ErrLog(errlog,progname,"Frequency Synthesizer in local mode.");
+
+      		if (tfreqA==-1) tfreqA=ftable->dfrq;
+      		if (tfreqB==-1) tfreqB=ftable->dfrq;
+
+      		sprintf(logtxt,"Channel A Transmitting on: %d (Noise=%g)",tfreqA,noiseA);
+      		ErrLog(errlog,progname,logtxt);
+
+      		sprintf(logtxt,"Channel B Transmitting on: %d (Noise=%g)",tfreqB,noiseB);
+      		ErrLog(errlog,progname,logtxt);
+
+      		SiteSetChannel(CHN_A);
+      		SiteSetFreq(tfreqA);
+      		SiteSetChannel(CHN_B);
+      		SiteSetFreq(tfreqB);
+
+	  	sprintf(logtxt,"Integrating:%2d,%2d intt:%d (%02d:%02d:%02d) %5d  %5d - %s  %d\n",
+		      	bmnumA, bmnumB, intsc, hr, mt, 
+              		sc, tfreqA, tfreqB,  
+              		OpsDayNight() ? "day" : "night", abs(tfreqA - tfreqB));
+      		ErrLog(errlog,progname,logtxt);
+      		u_read_uconts();
+
+      		txplA = (rsepA * 20) / 3;
+      		txplB = (rsepB * 20) / 3;
+      		tsgidA=SiteTimeSeqS(0,ptab);
+      		tsgidB=SiteTimeSeqS(1,ptab);
+
+      		SiteIntegrateS(lags,lags);   
+
+      		if (naveA<0) {
+        		sprintf(logtxt,"Integration A failed:%d",naveA);
+        		ErrLog(errlog,progname,logtxt); 
+        		continue;
+      		}
+      		if (naveB<0) {
+        		sprintf(logtxt,"Integration B failed:%d",naveB);
+        		ErrLog(errlog,progname,logtxt); 
+        		continue;
+      		}
+
+      		sprintf(logtxt,"Number of sequences: %d %d",naveA,naveB);
+      		ErrLog(errlog,progname,logtxt);
+
+      		OpsBuildRawS(0,&prmA,&rawA,ptab,lags);
+      		OpsBuildRawS(1,&prmB,&rawB,ptab,lags);
+
+      		FitACF(&prmA,&rawA,&fblk,&fitA);
+      		FitACF(&prmB,&rawB,&fblk,&fitB);
+
+      		ErrLog(errlog,progname,"Sending messages."); 
+      		msg.num=0;
+      		msg.tsize=0;
+      		RMsgSndAdd(&msg,sizeof(struct RadarParm),(unsigned char *) &prmA,
+			PRM_TYPE,0); 
+      		RMsgSndAdd(&msg,sizeof(struct RawData),(unsigned char *) &rawA,
+			RAW_TYPE,0);    
+      		RMsgSndAdd(&msg,sizeof(struct FitData),(unsigned char *) &fitA,
+			FIT_TYPE,0);
+      		RMsgSndAdd(&msg,strlen(progname)+1,progname,
+			NME_TYPE,0);   
+      		RMsgSndAdd(&msg,sizeof(struct RadarParm),(unsigned char *) &prmB,
+			PRM_TYPE,1); 
+      		RMsgSndAdd(&msg,sizeof(struct RawData),(unsigned char *) &rawB,
+			RAW_TYPE,1);    
+      		RMsgSndAdd(&msg,sizeof(struct FitData),(unsigned char *) &fitB,
+			FIT_TYPE,1);
+      		RMsgSndAdd(&msg,strlen(progname)+1,progname,
+			NME_TYPE,1);   
+      		for (n=0;n<tnum;n++) RMsgSndSend(tlist[n],&msg); 
+  
+      		ErrLog(errlog,progname,"Polling for exit."); 
+      		exitpoll=RadarShell(sid,&rstable);
+
+	  	/* Calculate delay offsets if stereo offset has been changed
+         		If stereo_offset is +ve A is later than B
+       		*/
+
+	  	if (stereo_offset > 0) {
+	    		delays[1] = 0;
+			delays[0] = stereo_offset / 10; /* stereo_offset is in usec */
+ 	  	} else {
+			delays[0] = 0;
+			delays[1] = (stereo_offset / 10) * (-1); /* stereo_offset is in usec */
+	  	}
+
+	  	if (exitpoll !=0) break;
+
+	  	scanA = 0;
+	  	scanB = 0;
+
+   	} 
+    
+	/* increment individual frequency band index. Doesn't matter whether
+	   individual frequency bands are being used for this channel or not.
+     	*/
+	/************  Sounding at end of scan ******************************/
+	
+	scanA=-2;
+	scanB=-2;
+        /* set sounding integration time to 1 second */
+  	intsc=1;
+  	intus=0;
+	/* step through array of 8 frequencies */
+	for(pcpcnt=0;pcpcnt<PCPFNUM;pcpcnt++){
+		/* use fixed beam for this sounding */
+      		bmnumA=PCPBEAM;
+      		bmnumB=PCPBEAM;
+      		TimeReadClock(&yr,&mo,&dy,&hr,&mt,&sc,&us);
+
+       		stfrqA=usfreq[pcpfreqs[pcpcnt]];
+       		frqrngA=ufreq_range[pcpfreqs[pcpcnt]];
+
+      		SiteSetChannel(CHN_B);
+      		SiteSetBeam(bmnumB);
+      		SiteSetChannel(CHN_A);
+      		SiteSetBeam(bmnumA);
+ 
+      		SiteSetIntt(intsc,intus);
+      		if (SiteFCLRS(stfrqA,stfrqA+frqrngA,stfrqB,
+                    stfrqB+frqrngB)==FREQ_LOCAL)
+        		ErrLog(errlog,progname,"Frequency Synthesizer in local mode.");
+
+      		if (tfreqA==-1) tfreqA=ftable->dfrq;
+      		if (tfreqB==-1) tfreqB=ftable->dfrq;
+
+      		sprintf(logtxt,"Channel A Transmitting on: %d (Noise=%g)",tfreqA,noiseA);
+      		ErrLog(errlog,progname,logtxt);
+
+      		sprintf(logtxt,"Channel B Transmitting on: %d (Noise=%g)",tfreqB,noiseB);
+      		ErrLog(errlog,progname,logtxt);
+
+      		SiteSetChannel(CHN_A);
+      		SiteSetFreq(tfreqA);
+      		SiteSetChannel(CHN_B);
+      		SiteSetFreq(tfreqB);
+	  	sprintf(logtxt,"Integrating:%2d,%2d intt:%d (%02d:%02d:%02d) %5d  %5d - %s  %d\n",
+		      	bmnumA, bmnumB, intsc, hr, mt, 
+              		sc, tfreqA, tfreqB,  
+              		OpsDayNight() ? "day" : "night", abs(tfreqA - tfreqB));
+      		ErrLog(errlog,progname,logtxt);
+      		u_read_uconts();
+
+      		txplA = (rsepA * 20) / 3;
+      		txplB = (rsepB * 20) / 3;
+      		tsgidA=SiteTimeSeqS(0,ptab);
+      		tsgidB=SiteTimeSeqS(1,ptab);
+
+      		SiteIntegrateS(lags,lags);   
+
+      		if (naveA<0) {
+        		sprintf(logtxt,"Integration A failed:%d",naveA);
+        		ErrLog(errlog,progname,logtxt); 
+        		continue;
+      		}
+      		if (naveB<0) {
+        		sprintf(logtxt,"Integration B failed:%d",naveB);
+        		ErrLog(errlog,progname,logtxt); 
+        		continue;
+      		}
+      		sprintf(logtxt,"Number of sequences: %d %d",naveA,naveB);
+      		ErrLog(errlog,progname,logtxt);
+
+      		OpsBuildRawS(0,&prmA,&rawA,ptab,lags);
+      		OpsBuildRawS(1,&prmB,&rawB,ptab,lags);
+
+      		FitACF(&prmA,&rawA,&fblk,&fitA);
+      		FitACF(&prmB,&rawB,&fblk,&fitB);
+
+      		ErrLog(errlog,progname,"Sending messages."); 
+      		msg.num=0;
+      		msg.tsize=0;
+      		RMsgSndAdd(&msg,sizeof(struct RadarParm),(unsigned char *) &prmA,
+			PRM_TYPE,0); 
+      		RMsgSndAdd(&msg,sizeof(struct RawData),(unsigned char *) &rawA,
+			RAW_TYPE,0);    
+      		RMsgSndAdd(&msg,sizeof(struct FitData),(unsigned char *) &fitA,
+			FIT_TYPE,0);
+      		RMsgSndAdd(&msg,strlen(progname)+1,progname,
+			NME_TYPE,0);   
+      		RMsgSndAdd(&msg,sizeof(struct RadarParm),(unsigned char *) &prmB,
+			PRM_TYPE,1); 
+      		RMsgSndAdd(&msg,sizeof(struct RawData),(unsigned char *) &rawB,
+			RAW_TYPE,1);    
+      		RMsgSndAdd(&msg,sizeof(struct FitData),(unsigned char *) &fitB,
+			FIT_TYPE,1);
+      		RMsgSndAdd(&msg,strlen(progname)+1,progname,
+			NME_TYPE,1);   
+      		for (n=0;n<tnum;n++) RMsgSndSend(tlist[n],&msg); 
+      		ErrLog(errlog,progname,"Polling for exit."); 
+      		exitpoll=RadarShell(sid,&rstable);
+
+	  	/* Calculate delay offsets if stereo offset has been changed
+         		If stereo_offset is +ve A is later than B
+       		*/
+
+	  	if (stereo_offset > 0) {
+	    		delays[1] = 0;
+			delays[0] = stereo_offset / 10; /* stereo_offset is in usec */
+ 	  	} else {
+			delays[0] = 0;
+			delays[1] = (stereo_offset / 10) * (-1); /* stereo_offset is in usec */
+	  	}
+
+	  	if (exitpoll !=0) break;
+
+
+
+	}
+	scanA = 0;
+	scanB = 0;
+
+	/************  Sounding at end of scan ******************************/
+
+    	ErrLog(errlog,progname,"Waiting for scan boundary."); 
+    	if ((scnsc !=0) || (scnus !=0)) {
+      		if (exitpoll==0) OpsWaitBoundary(scnsc,scnus);
+    	}
+  } while (exitpoll==0);
+  SiteEnd();
+  for (n=0;n<tnum;n++) RMsgSndClose(tlist[n]);
+  ErrLog(errlog,progname,"Ending program.");
+  RShellTerminate(sid);
+  return 0;   
+} 
+ 
+
+/***************************************************************************/
+
+/* Sets up the licenced frequency bands for Iceland & finland */
+
+void u_init_freq_bands() {
+
+/* start freq of each band */
+
+   /* Finland */
+
+   usfreq[0] = 8305;
+   usfreq[1] = 8965;
+   usfreq[2] = 9900;
+   usfreq[3] = 11075;
+   usfreq[4] = 11550;
+   usfreq[5] = 12370;
+   usfreq[6] = 13200;
+   usfreq[7] = 15010;
+   usfreq[8] = 16210;
+   usfreq[9] = 16555;
+   usfreq[10] = 17970;
+   usfreq[11] = 18850;
+   usfreq[12] = 19415;
+   usfreq[13] = 19705;
+   usfreq[14] = 19800;
+
+   /* Iceland */
+
+   usfreq[20] = 8000;
+   usfreq[21] = 8430;
+   usfreq[22] = 8985;
+   usfreq[23] = 10155;
+   usfreq[24] = 10655;
+   usfreq[25] = 11290;
+   usfreq[26] = 11475;
+   usfreq[27] = 12105;
+   usfreq[28] = 12305;
+   usfreq[29] = 12590;
+   usfreq[30] = 13360;
+   usfreq[31] = 13875;
+   usfreq[32] = 14400;
+   usfreq[33] = 15805;
+   usfreq[34] = 16500;
+   usfreq[35] = 16820;
+   usfreq[36] = 18175;
+   usfreq[37] = 18835;
+   usfreq[38] = 19910;
+   usfreq[39] = 10155;
+
+   /* width of each band */
+
+   /* Finland */
+
+   ufreq_range[0] = 30;
+   ufreq_range[1] = 75;
+   ufreq_range[2] = 85;
+   ufreq_range[3] = 200;
+   ufreq_range[4] = 50;
+   ufreq_range[5] = 45;
+   ufreq_range[6] = 60;
+   ufreq_range[7] = 70;
+   ufreq_range[8] = 150;
+   ufreq_range[9] = 60;
+   ufreq_range[10] = 80;
+   ufreq_range[11] = 15;
+   ufreq_range[12] = 265;
+   ufreq_range[13] = 50;
+   ufreq_range[14] = 190; 
+
+   /* Iceland */
+
+   ufreq_range[20] = 195;
+   ufreq_range[21] = 420;
+   ufreq_range[22] = 410;
+   ufreq_range[23] = 500;
+   ufreq_range[24] = 520;
+   ufreq_range[25] = 160;
+   ufreq_range[26] = 120;
+   ufreq_range[27] = 130;
+   ufreq_range[28] = 205;
+   ufreq_range[29] = 690;
+   ufreq_range[30] = 205;
+   ufreq_range[31] = 120;
+   ufreq_range[32] = 615;
+   ufreq_range[33] = 560;
+   ufreq_range[34] = 185;
+   ufreq_range[35] = 655;
+   ufreq_range[36] = 595;
+   ufreq_range[37] = 50;
+   ufreq_range[38] = 90;
+   ufreq_range[39] = 1020;
+}
+
+/* Sends a proxy message to the microcontroller monitoring 
+   task every beam.
+*/
+
+void u_read_uconts() {
+  if (uucont_proxy != 0) Trigger(uucont_proxy);
+}
+

--- a/qnx4/sd_leicester/han/pcpstereoscan.1.02/version.info
+++ b/qnx4/sd_leicester/han/pcpstereoscan.1.02/version.info
@@ -1,0 +1,9 @@
+# $Log: version.info,v $
+# Revision 1.2  2006/07/12 15:51:55  code
+# Added call to set up command line and limited data written to rawacf and fitacf.
+#
+# Revision 1.1  2006/03/30 11:28:25  barnes
+# Initial revision
+#
+#
+pcpstereoscan.c 1.02

--- a/qnx4/sd_leicester/han/stereoscan.1.04/makefile
+++ b/qnx4/sd_leicester/han/stereoscan.1.04/makefile
@@ -1,0 +1,55 @@
+# Makefile for stereoscan
+# =======================
+# by R.J.Barnes
+#
+#
+
+
+INCLUDE=-I$(IPATH)/base -I$(IPATH)/general -I$(IPATH)/superdarn \
+	-I$(IPATH)/radarqnx4 \
+	-I$(USR_IPATH)/radarqnx4/ops \
+	-I$(USR_IPATH)/radarqnx4/site.$(SD_RADARCODE)
+
+OBJS = stereoscan.o
+SRC=stereoscan.c
+IGNVER=1
+OUTPUT = $(USR_BINPATH)/stereoscan
+SUDO = 1 
+LIBS=-lsite.${SD_RADARCODE}.1 -lops.1 -lfitacf.1 -lradar.1 -lerrlog.1 \
+     -lrs.1 -lfreq.1 -lacf.1 -ltcpipmsg.1 -lrawfeed.1 -ltsg.1  \
+     -ltaskid.1 -lrmsgsnd.1 -lrtimer.1 -lrtime.1 -lrmath.1 -lopt.1 
+
+include $(SITELIB).${SD_RADARCODE}
+
+ifdef STEREO
+include $(MAKEBIN)
+else
+version: version.info $(SRC)
+	$(BINPATH)/rcsv -t version.info
+clean:
+	rm -f *.o
+	rm -f $(OUTPUT)
+endif
+
+
+
+
+
+
+
+  
+
+
+
+
+
+
+
+
+
+  
+
+
+ 
+
+

--- a/qnx4/sd_leicester/han/stereoscan.1.04/stereoscan.c
+++ b/qnx4/sd_leicester/han/stereoscan.1.04/stereoscan.c
@@ -1,0 +1,1271 @@
+/* stereoscan.c
+   ============
+   Author: R.J.Barnes
+*/
+
+/*
+ Copyright 2004 The Johns Hopkins University/Applied Physics Laboratory.
+ All rights reserved.
+ 
+ This material may be used, modified, or reproduced by or for the U.S.
+ Government pursuant to the license rights granted under the clauses at DFARS
+ 252.227-7013/7014.
+ 
+ For any other permissions, please contact the Space Department
+ Program Office at JHU/APL.
+ 
+ This Distribution and Disclaimer Statement must be included in all copies of
+ "Radar Operating System - Control Programs" (hereinafter "the Program").
+ 
+ The Program was developed at The Johns Hopkins University/Applied Physics
+ Laboratory (JHU/APL) which is the author thereof under the "work made for
+ hire" provisions of the copyright law.  
+ 
+ JHU/APL assumes no obligation to provide support of any kind with regard to
+ the Program.  This includes no obligation to provide assistance in using the
+ Program or to provide updated versions of the Program.
+ 
+ THE PROGRAM AND ITS DOCUMENTATION ARE PROVIDED AS IS AND WITHOUT ANY EXPRESS
+ OR IMPLIED WARRANTIES WHATSOEVER.  ALL WARRANTIES INCLUDING, BUT NOT LIMITED
+ TO, PERFORMANCE, MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE ARE
+ HEREBY DISCLAIMED.  YOU ASSUME THE ENTIRE RISK AND LIABILITY OF USING THE
+ PROGRAM TO INCLUDE USE IN COMPLIANCE WITH ANY THIRD PARTY RIGHTS.  YOU ARE
+ ADVISED TO TEST THE PROGRAM THOROUGHLY BEFORE RELYING ON IT.  IN NO EVENT
+ SHALL JHU/APL BE LIABLE FOR ANY DAMAGES WHATSOEVER, INCLUDING, WITHOUT
+ LIMITATION, ANY LOST PROFITS, LOST SAVINGS OR OTHER INCIDENTAL OR
+ CONSEQUENTIAL DAMAGES, ARISING OUT OF THE USE OR INABILITY TO USE THE
+ PROGRAM."
+ 
+ 
+ 
+ 
+ 
+  
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/types.h>
+#include <sys/proxy.h>
+#include <sys/kernel.h>
+#include <string.h>
+#include <time.h>
+#include "rtypes.h"
+#include "option.h"
+#include "rtime.h"
+#include "limit.h"
+#include "radar.h"
+#include "rprm.h"
+#include "rawdata.h"
+#include "fitblk.h"
+#include "fitdata.h"
+#include "fitacf.h"
+
+#include "taskid.h"
+#include "errlog.h"
+#include "freq.h"
+#include "rmsg.h"
+#include "radarshell.h"
+#include "rmsgsnd.h"
+#include "tsg.h"
+#include "tsgtable.h"
+#include "maketsg.h"
+#include "global.h"
+#include "globals.h"
+#include "setup.h"
+#include "reopen.h"
+#include "tmseq.h"
+#include "raws.h"
+#include "sync.h"
+#include "interface.h"
+#include "hdw.h"
+
+/*
+ $Log: stereoscan.c,v $
+ Revision 1.4  2007/08/09 14:09:51  code
+ Allowed command lines to be passed as a file.
+
+ Revision 1.3  2007/08/08 16:55:44  code
+ Fixed bug in using hex notation for stid.
+
+ Revision 1.2  2006/07/12 15:51:43  code
+ Added call to set up command line and limited data written to rawacf and fitacf.
+
+ Revision 1.1  2006/03/30 11:19:18  barnes
+ Initial revision
+ 
+*/
+
+/*
+	Modified 10/12/2001 PH
+
+	Added bnA and bnB frequency band options to cycle through frequency
+	bands during each scan. No check is made for invalid band numbers.
+	A band number of -1 is ignored. Bands can be added/removed at any
+	time using radar_shell, changes won't take effect until the end of
+	the current scan. If no band numbers are specified, normal day/night
+	frequencies are used.
+
+	Frequency bands can also be specified for campA and campB modes.
+
+	Extra options can be placed in a separate schedule file. The file
+	name should be the last argument in the schedule argument list and
+	should include the full path.
+
+	Modified 16/01/02 PH
+
+	Fixed synchronisation bug. The code wasn't subtracting the time taken
+	for a clear frequency search from the beam integration time, resulting
+	in an extended beam dwell time and a sweep lasting for more than 60 s
+	for fast stereo and 120 s for slow stereo 7 s integration.
+
+	Standard slow stereo (normal stereo) is now 7 seconds (by Mark Lester).
+
+	Modified 30/01/02 PH
+
+	added -cts? options that pre-set other options
+
+			dwell	chan A	cpidA	chan B	cpidB	Ice/Fin	offset	range
+			------	------	------	------	------	------- ------	-----
+	cts2 -    7		normal	 152	 tbj	-26002	 5 / 9	 +400	 45
+	cts4 -	  7		normal	 152	normal	-26004	 5 / 9	 +400	 45
+	cts6 -	  7		normal	 152	1 camp	-26006	 5 / 9	 +400	 45
+	cts8 -	  7		normal	 152	2 camp	-26008	 5 / 9	 +400	 45
+
+	cts3 -	  3		normal	 153	 tbj	-26003	 5 / 9	 +400	 45
+	cts5 -	  3		normal	 153	normal	-26005	 5 / 9	 +400	 45
+	cts7 -	  3		normal	 153	1 camp	-26007	 5 / 9	 +400	 45
+	cts9 -	  3		normal	 153	2 camp	-26009	 5 / 9	 +400	 45
+
+	Single camp beams are hard coded to the standard Finland beam 9 and
+	Iceland beam 5.
+
+	Double camp beams are the same for both radars and defined as
+	DOUBLE_CAMP_LOW and DOUBLE_CAMP_HIGH.
+
+	range gates and first range are let to the default settings of 45km
+	and 180km respectively.
+
+	specifying any cts option will override low and high beam, offset, cpIDs,
+	integration time and scan boundary. tbj mode overrides frequencies.
+
+	Modified 05/04/02 PH
+
+	Uses the new stereo aware version of fitacf (1.06).
+
+	Modified 30/04/2002 PH
+
+	Added cpidA and cpidB to set the cpid. This option overrides any
+	previously defined cpid.
+
+	Added bmnA and bmnB to cycle through beams numbers on both channels.
+	To specify double camp beams use -bm0B 5 -bm1B 9
+	To specify single camp beams use -bm0B 5
+	The same beam number can be specified more than once.
+	The number of beams in the channel A beam list determines the number of
+	beams per scan. This is important if you are also using frequency lists.
+
+	cts 2, 3, 4, 5 beams patterns can be changed with bm*A and bm*B options.
+
+	Modified 25/09/02 PH
+
+	Changed so that the B channel frequency band changes at the end of the
+	channel B scan, so that it is independent of the number of beams on
+	channel A.
+
+  Modified 7th Dec 2001 to add camp beam flags
+  Modified 23 Nov 2001 to add new -ns and -fs flags and changed some defaults
+  Modified 10th Aug to account for backwards scanning radars
+  Modified 8th Aug fitacf_s
+  Julian modified version. March 2001
+
+*/
+
+#define CPID_A -6401
+#define CPID_B -26401
+#define CPID_NS 152
+#define CPID_FS 153
+
+
+#define INTT      7
+#define RSEP_A 45
+#define RSEP_B 45
+#define FRANG_A 180
+#define FRANG_B 180
+
+
+#define LOW_BEAM_A   0
+#define HIGH_BEAM_A  15
+#define LOW_BEAM_B   0
+#define HIGH_BEAM_B  15
+
+#define SINGLE_CAMP_BEAM_PYK 5
+#define SINGLE_CAMP_BEAM_HAN 9
+
+
+#define DOUBLE_CAMP_LOW 5
+#define DOUBLE_CAMP_HIGH 9
+
+#define UCONT_NAME "ucont_moni"
+
+#define CHN_A 0
+#define CHN_B 1
+
+#define NUMBANDS 10
+#define NUMBEAMS 16
+
+
+#define SCHEDULER "schedule"
+#define ERRLOG "errlog"
+
+#define CONTROL_NAME "control_program"
+#define TASK_NAMES "echo_data","rawacfwrite","fitacfwrite"
+
+
+
+void u_read_uconts(void);
+void u_init_freq_bands(void);
+
+void RemInvalidEntries(int ifreqsA[], int ifreqsB[]);
+void FindNumBands(int *numfreqbandsA, int *numfreqbandsB, int *day_nightA, int *day_nightB, int ifreqsA[], int ifreqsB[], int print);
+void RemInvalidBeams(int ibeamsA[], int ibeamsB[]);
+void FindNumBeams(int *numbeamsA, int *numbeamsB, int ibeamsA[], int ibeamsB[], int print);
+
+char cmdlne[1024];
+char progid[80]={"$Id: stereoscan.c,v 1.4 2007/08/09 14:09:51 code Exp $"};
+char progname[256];
+struct TaskID *errlog;
+
+int usfreq[42];
+int ufreq_range[42];
+
+pid_t uucont_proxy;
+
+int low_beam_A=LOW_BEAM_A;
+int high_beam_A=HIGH_BEAM_A;
+int low_beam_B=LOW_BEAM_B;
+int high_beam_B=HIGH_BEAM_B;
+
+
+
+
+char *tasklist[]=
+ { TASK_NAMES,
+  0};
+
+int arg=0;
+struct OptionData opt;
+struct OptionFile *optf=NULL;
+      
+int main(int argc,char *argv[]) {
+
+  int ptab[7] = {0,9,12,20,22,26,27};
+
+  int lags[LAG_SIZE][2] = {
+    { 0, 0},		/*  0 */
+    {26,27},		/*  1 */
+    {20,22},		/*  2 */
+    {9,12},		/*  3 */
+    {22,26},		/*  4 */
+    {22,27},		/*  5 */
+
+    {20,26},		/*  7 */
+    {20,27},		/*  8 */
+    {0,9},		/*  9 */
+    {12,22},		/* 10 */
+    {9,20},		/* 11 */
+    {0,12},	  	    /* 12 */
+    {9,22},		/* 13 */
+    {12,26},		/* 14 */
+    {12,27},		/* 15 */
+    {9,26},		/* 16 */
+    {9,27},		/* 17 */
+    {27,27}};		/* alternate lag-0  */
+
+
+  char *sname=NULL;
+  char *ename=NULL;
+  char *sdname={SCHEDULER};
+  char *edname={ERRLOG};
+  char logtxt[1024];
+
+  char a[10];
+
+  int n,i;
+  pid_t sid;
+  int exitpoll=0;
+ 
+  int scnsc=0;
+  int scnus=0;
+ 
+  unsigned char ns=0;
+  unsigned char fs=0;
+
+  int stereo_offset=400; /* channel A delayed by this 
+                            number of microseconds */
+
+
+  int ifreqsA[NUMBANDS],ifreqsB[NUMBANDS];
+
+  int ibeamsA[NUMBEAMS],ibeamsB[NUMBEAMS];
+
+  int day_nightA=1;
+  int day_nightB=1;
+
+  int numfreqbandsA;
+  int numfreqbandsB;
+  
+  int ifreqsA_index=0; 
+  int ifreqsB_index=0;
+  
+  int ifreqsAband;
+  int ifreqsBband;
+
+  int numbeamsA,numbeamsB;
+
+  int ibeamsA_index=0;
+  int ibeamsB_index=0;
+
+  unsigned char cts2=0,cts4=0,cts6=0,cts8=0;
+  unsigned char cts3=0,cts5=0,cts7=0,cts9=0;
+  
+  int cpidA=0,cpidB=0;
+
+  for (i=0;i<NUMBANDS;i++) ifreqsA[i]=ifreqsB[i]=-1;
+  for (i=0;i<NUMBEAMS;i++) ibeamsA[i]=ibeamsB[i]=-1;
+  
+  xcfA=xcfB=1;
+ 
+  cpA=CPID_A;
+  cpB=CPID_B;
+
+  SiteStart();
+ 
+  intsc=INTT;
+  intus=0;
+ 
+  maxattenA=maxattenB=7;
+
+  if ((uucont_proxy=SiteInitProxy(UCONT_NAME))==-1) {
+    perror("cannot attach proxy");
+  }
+ 
+  u_init_freq_bands();
+  
+  strcpy(cmdlne,argv[0]);
+  for (n=1;n<argc;n++) {
+    strcat(cmdlne," ");
+    strcat(cmdlne,argv[n]);
+  } 
+
+  strncpy(combf,progid,80);   
+  OpsSetupCommand(argc,argv);
+  OpsSetupRadar();
+  OpsSetupShell();
+
+  RadarShellAdd(&rstable,"intt",var_LONG,&intsc);
+  RadarShellAdd(&rstable,"inttsc",var_LONG,&intsc);
+  RadarShellAdd(&rstable,"inttus",var_LONG,&intus);
+
+  RadarShellAdd(&rstable,"txplA",var_LONG,&txplA);
+  RadarShellAdd(&rstable,"mpincA",var_LONG,&mpincA);
+  RadarShellAdd(&rstable,"mppulA",var_LONG,&mppulA);
+  RadarShellAdd(&rstable,"mplgsA",var_LONG,&mplgsA);
+  RadarShellAdd(&rstable,"nrangA",var_LONG,&nrangA);
+  RadarShellAdd(&rstable,"frangA",var_LONG,&frangA);
+  RadarShellAdd(&rstable,"rsepA",var_LONG,&rsepA);
+  RadarShellAdd(&rstable,"bmnumA",var_LONG,&bmnumA);
+  RadarShellAdd(&rstable,"xcfA",var_LONG,&xcfA);
+  RadarShellAdd(&rstable,"tfreqA",var_LONG,&tfreqA);
+  RadarShellAdd(&rstable,"scanA",var_LONG,&scanA);
+  RadarShellAdd(&rstable,"mxpwrA",var_LONG,&mxpwrA);
+  RadarShellAdd(&rstable,"lvmaxA",var_LONG,&lvmaxA);
+  RadarShellAdd(&rstable,"rxriseA",var_LONG,&rxriseA);
+  RadarShellAdd(&rstable,"combfA",var_STRING,combfA);
+  RadarShellAdd(&rstable,"cpA",var_LONG,&cpA);
+
+  RadarShellAdd(&rstable,"txplB",var_LONG,&txplB);
+  RadarShellAdd(&rstable,"mpincB",var_LONG,&mpincB);
+  RadarShellAdd(&rstable,"mppulB",var_LONG,&mppulB);
+  RadarShellAdd(&rstable,"mplgsB",var_LONG,&mplgsB);
+  RadarShellAdd(&rstable,"nrangB",var_LONG,&nrangB);
+  RadarShellAdd(&rstable,"frangB",var_LONG,&frangB);
+  RadarShellAdd(&rstable,"rsepB",var_LONG,&rsepB);
+  RadarShellAdd(&rstable,"bmnumB",var_LONG,&bmnumB);
+  RadarShellAdd(&rstable,"xcfB",var_LONG,&xcfB);
+  RadarShellAdd(&rstable,"tfreqB",var_LONG,&tfreqB);
+  RadarShellAdd(&rstable,"scanB",var_LONG,&scanB);
+  RadarShellAdd(&rstable,"mxpwrB",var_LONG,&mxpwrB);
+  RadarShellAdd(&rstable,"lvmaxB",var_LONG,&lvmaxB);
+  RadarShellAdd(&rstable,"rxriseB",var_LONG,&rxriseB);
+  RadarShellAdd(&rstable,"combfB",var_STRING,combfB);
+  RadarShellAdd(&rstable,"cpB",var_LONG,&cpB);
+
+  OptionAdd(&opt, "ns",	'x', &ns);
+  OptionAdd(&opt, "fs",	'x', &fs);
+  OptionAdd(&opt, "e",	't', &ename);  
+  OptionAdd(&opt, "sc",	't', &sname);
+  OptionAdd(&opt, "intt",	'i', &intsc);
+  OptionAdd(&opt, "dfA",	'i', &dfrqA);
+  OptionAdd(&opt, "dfB",	'i', &dfrqB);
+  OptionAdd(&opt, "nfA",	'i', &nfrqA);
+  OptionAdd(&opt, "nfB",	'i', &nfrqB);
+  
+  OptionAdd(&opt, "offset",	'i',&stereo_offset);
+
+  OptionAdd(&opt, "frA",	'i', &frangA);
+  OptionAdd(&opt, "frB",	'i', &frangB);
+  OptionAdd(&opt, "rgA",	'i', &rsepA);
+  OptionAdd(&opt, "rgB",	'i', &rsepB);
+  OptionAdd(&opt, "lbA",	'i', &low_beam_A);
+  OptionAdd(&opt, "hbA",	'i', &high_beam_A);
+  OptionAdd(&opt, "lbB",	'i', &low_beam_B);
+  OptionAdd(&opt, "hbB",	'i', &high_beam_B);
+  OptionAdd(&opt, "sp",	'i', &scnsc);
+
+  OptionAdd(&opt, "cpidA", 'i', &cpidA);
+  OptionAdd(&opt, "cpidB", 'i', &cpidB);
+
+  /* set up remaining shell variables */
+
+  RadarShellAdd(&rstable, "dfA",var_LONG,&dfrqA);
+  RadarShellAdd(&rstable, "dfB",var_LONG,&dfrqB);
+  RadarShellAdd(&rstable, "nfA",var_LONG,&nfrqA);
+  RadarShellAdd(&rstable, "nfB",var_LONG,&nfrqB);
+
+  RadarShellAdd(&rstable, "offset",	var_LONG,&stereo_offset);
+ 
+  RadarShellAdd(&rstable, "low_beamA",	var_LONG,&low_beam_A);
+  RadarShellAdd(&rstable, "high_beamA",var_LONG,&high_beam_A);
+  RadarShellAdd(&rstable, "low_beamB",	var_LONG,&low_beam_B);
+  RadarShellAdd(&rstable, "high_beamB",var_LONG,&high_beam_B);
+  RadarShellAdd(&rstable, "scan_period",var_LONG,&scnsc);
+
+  /* add new options - individual frequency bands */
+
+  strcpy(a,"b0A");
+  for (i = 0; i < NUMBANDS; i++) {
+    a[1] = '0' + i; /* change 2nd char to ACSII number */
+    OptionAdd(&opt, a,	'i', &ifreqsA[i]);
+    RadarShellAdd(&rstable, a, var_LONG, &ifreqsA[i]);
+  }
+
+  strcpy(a,"b0B");
+  for (i = 0; i < NUMBANDS; i++) {
+    a[1] = '0' + i; /* change 2nd char to ACSII number */
+    OptionAdd(&opt, a,	'i', &ifreqsB[i]);
+    RadarShellAdd(&rstable, a, var_LONG, &ifreqsB[i]);
+  }
+
+  strcpy(a,"bm0A");
+  
+  for (i = 0; i < 10; i++) {
+    a[2] = '0' + i;  /* change 3nd char to ACSII number */
+    OptionAdd(&opt, a,	'i', &ibeamsA[i]);
+    RadarShellAdd(&rstable, a, var_LONG, &ibeamsA[i]);
+  }
+
+  strcpy(a,"bm10A");
+  for (i = 0; i < 6; i++) {
+    a[3] = '0' + i;  /* change 4nd char to ACSII number */
+    OptionAdd(&opt, a,	'i', &ibeamsA[i + 10]);
+    RadarShellAdd(&rstable, a, var_LONG, &ibeamsA[i + 10]);
+  }
+
+  strcpy(a,"bm0B");
+  for (i = 0; i < 10; i++) {
+    a[2] = '0' + i;  /* change 3nd char to ACSII number */
+    OptionAdd(&opt, a,	'i', &ibeamsB[i]);
+    RadarShellAdd(&rstable, a, var_LONG, &ibeamsB[i]);
+  }
+
+  strcpy(a,"bm10B");
+  for (i = 0; i < 6; i++) {
+    a[3] = '0' + i; /* change 4nd char to ACSII number */
+    OptionAdd(&opt, a,	'i', &ibeamsB[i + 10]);
+    RadarShellAdd(&rstable, a, var_LONG, &ibeamsB[i + 10]);
+  }
+
+  /* add CTs options */
+
+  OptionAdd(&opt, "cts2", 'x', &cts2);
+  OptionAdd(&opt, "cts3", 'x', &cts3);
+  OptionAdd(&opt, "cts4", 'x', &cts4);
+  OptionAdd(&opt, "cts5", 'x', &cts5);
+  OptionAdd(&opt, "cts6", 'x', &cts6);
+  OptionAdd(&opt, "cts7", 'x', &cts7);
+  OptionAdd(&opt, "cts8", 'x', &cts8);
+  OptionAdd(&opt, "cts9", 'x', &cts9);
+ 
+  arg=OptionProcess(1,argc,argv,&opt,NULL); 
+
+  if (arg<argc) {
+    int farg;
+    FILE *fp=NULL;
+    fp=fopen(argv[arg],"r");
+    if (fp!=NULL) {
+      optf=OptionProcessFile(fp);
+      if (optf !=NULL) {
+        farg=OptionProcess(0,optf->argc,optf->argv,&opt,NULL);
+        OptionFreeFile(optf);
+      }   
+      fclose(fp);
+    }
+  }
+ 
+  if (sname==NULL) sname=sdname;
+  if (ename==NULL) ename=edname;
+
+  sid=RShellRegister(sname,CONTROL_NAME);
+
+  errlog=TaskIDMake(ename);  
+  OpsLogStart(errlog,progname,argc,argv);  
+
+  /* handle CTs */
+
+  if ((cts2) || (cts4) || (cts6) || (cts8)) {
+    cpA = 152;
+	intsc = 7;
+    intus = 0;
+    stereo_offset = 400;
+    scnsc = 120;
+    scnus = 0;
+
+	/* tbj mode */
+
+    if (cts2) {
+	  cpB = -26002;
+      if (stid==9) {
+	    ifreqsB[0] = 23;
+		ifreqsB[1] = 26;
+		ifreqsB[2] = 28;
+		ifreqsB[3] = 30;
+		ifreqsB[4] = 32;
+		ifreqsB[5] = 34;
+		ifreqsB[6] = 35;
+      } else if (stid==10) {
+		ifreqsB[0] = 2;
+		ifreqsB[1] = 4;
+		ifreqsB[2] = 5;
+		ifreqsB[3] = 6;
+		ifreqsB[4] = 7;
+		ifreqsB[5] = 8;
+		ifreqsB[6] = 10;
+      }
+     }
+
+	 /* normal scan */
+
+	 if (cts4) cpB = -26004;
+	
+	 /* single camp beam */
+
+	if (cts6) {
+	  cpB = -26006;
+      if (stid==9) ibeamsB[0] = SINGLE_CAMP_BEAM_PYK;
+      else ibeamsB[0] = SINGLE_CAMP_BEAM_HAN;
+
+	}
+
+	/* double camp beam */
+
+	if (cts8) {
+	  cpB = -26008;
+
+	  ibeamsB[0] = DOUBLE_CAMP_LOW;
+	  ibeamsB[1] = DOUBLE_CAMP_HIGH;
+	}
+  } else if ((cts3) || (cts5) || (cts7) || (cts9)) {
+    cpA = 153;
+	intsc = 3;
+	stereo_offset = 400;
+	scnsc = 60.0;
+    scnus = 0.0;
+
+	/* tbj */
+
+	if (cts3) {
+	  cpB = -26003;
+       
+	  if (stid==9) {
+	    ifreqsB[0] = 23;
+		ifreqsB[1] = 26;
+		ifreqsB[2] = 28;
+		ifreqsB[3] = 30;
+		ifreqsB[4] = 32;
+		ifreqsB[5] = 34;
+		ifreqsB[6] = 35;
+      } else if (stid==10) {
+		ifreqsB[0] = 2;
+		ifreqsB[1] = 4;
+		ifreqsB[2] = 5;
+		ifreqsB[3] = 6;
+		ifreqsB[4] = 7;
+		ifreqsB[5] = 8;
+		ifreqsB[6] = 10;
+      }
+	}
+
+	/* normal scan */
+
+	if (cts5) cpB = -26005;
+	
+
+	/* single camp beam */
+
+	if (cts7) {
+	  cpB = -26007;
+      if (stid==9) ibeamsB[0] = SINGLE_CAMP_BEAM_PYK;
+      else ibeamsB[0] = SINGLE_CAMP_BEAM_HAN;
+
+	}
+
+	/* double camp beam */
+
+	if (cts9) {
+	  cpB = -26009;
+
+	  ibeamsB[0] = DOUBLE_CAMP_LOW;
+	  ibeamsB[1] = DOUBLE_CAMP_HIGH;
+	}
+  } else
+    /* check for normal scan emulation */
+  if (ns) {
+    frangA		= FRANG_A;
+	rsepA		= RSEP_A;
+	low_beam_A	= LOW_BEAM_A;
+	high_beam_A	= HIGH_BEAM_A;
+
+	intsc = 7;
+    intus = 0;
+	scnsc = 120.0;
+    scnus = 0.0;
+	cpA = CPID_NS;  
+  } else
+    /* check for fast scan emulation */
+  if (fs) {
+    frangA		= FRANG_A;
+	rsepA		= RSEP_A;
+	low_beam_A	= LOW_BEAM_A;
+	high_beam_A	= HIGH_BEAM_A;
+
+	intsc = 3;
+    intus = 0;
+	scnsc = 60.0;
+    scnus = 0.0;
+	cpA = CPID_FS;
+  }
+
+  /* set cpid for channel A */
+
+  if (cpidA) {
+     cpA = cpidA;
+	 cpB = -1 * abs(cpidA) - 20000;
+  }
+
+  /* set cpid for channel B */
+
+  if (cpidB) cpB = cpidB;
+	
+  /* Calculate delay offsets
+     If stereo_offset is +ve A is later than B
+  */
+
+  if (stereo_offset > 0) {
+    delays[1] = 0;
+	delays[0] = stereo_offset / 10; /* remember stereo_offset is in usec */
+  } else {
+    delays[0] = 0;
+	delays[1] = (stereo_offset / 10) * (-1); /* stereo_offset is in usec */
+  }
+
+  mppulA = mppulB = 7;
+  mplgsA = mplgsB = 18;
+
+  txplA = (rsepA * 20) / 3;
+  txplB = (rsepB * 20) / 3;
+
+  /* just a dummy frequency */
+
+  tfreqA = 13500;
+  tfreqB = 14500; 
+
+  SiteSetupHardware();
+
+  /* remove invalid entries in the frequency band lists */
+
+  RemInvalidEntries(ifreqsA, ifreqsB);
+
+  /* determine the number of frequency bands */
+
+  FindNumBands(&numfreqbandsA, &numfreqbandsB, 
+               &day_nightA, &day_nightB, ifreqsA, ifreqsB, 1);
+
+  /* check beams */
+
+  if (low_beam_A  <  LOW_BEAM_A) low_beam_A  = LOW_BEAM_A;
+  if (high_beam_A > HIGH_BEAM_A) high_beam_A = HIGH_BEAM_A;
+
+  if (low_beam_B  <  LOW_BEAM_B) low_beam_B  = LOW_BEAM_B;
+  if (high_beam_B > HIGH_BEAM_B) high_beam_B = HIGH_BEAM_B;
+
+  /* end beams in the wrong order */
+
+  if (low_beam_A > high_beam_A) {
+    int beam = high_beam_A;
+    high_beam_A = low_beam_A;
+	low_beam_A  = beam;
+  }
+
+  if (low_beam_B > high_beam_B) {
+    int beam = high_beam_B;
+    high_beam_B = low_beam_B;
+	low_beam_B  = beam;
+  }
+
+  /* sort beam lists */
+
+  RemInvalidBeams(ibeamsA, ibeamsB);			
+  FindNumBeams(&numbeamsA, &numbeamsB, ibeamsA, ibeamsB, 1);
+
+  /*
+	the beam lists now contain:
+	1) the number of beams in the beam lists
+	2) if no beam list or camp beams were specified = 0 -> 15
+	3) if high and low beams were specified			= low_beam -> high_beam
+  */
+   
+  sprintf(progname,"stereoscan");
+
+  OpsFitACFStart();
+
+  OpsSetupTask(tasklist);
+  for (n=0;n<tnum;n++) {
+    RMsgSndReset(tlist[n]);
+    RMsgSndOpen(tlist[n],strlen(cmdlne),cmdlne);     
+  }
+
+  /* scan loop */
+
+  do {
+
+    if (SiteStartScan()==0) continue;
+
+    if (OpsReOpen(2,0,0) !=0) {
+      ErrLog(errlog,progname,"Opening new files.");
+      for (n=0;n<tnum;n++) {
+        RMsgSndClose(tlist[n]);
+        RMsgSndOpen(tlist[n],strlen(cmdlne),cmdlne);     
+      }
+    }
+
+    if (backward) scanA=scanB=-1;
+    else scanA=scanB=1; 
+
+    ErrLog(errlog,progname,"Starting scan.");
+
+
+    for (ibeamsA_index=0;ibeamsA_index<numbeamsA;ibeamsA_index++) {
+
+      bmnumA=ibeamsA[ibeamsA_index];
+      bmnumB=ibeamsB[ibeamsB_index];
+
+	  ifreqsAband = ifreqsA[ifreqsA_index];
+	  ifreqsBband = ifreqsB[ifreqsB_index];
+
+      TimeReadClock(&yr,&mo,&dy,&hr,&mt,&sc,&us);
+
+      if (day_nightA) { 
+        if (OpsDayNight()==1) {
+           stfrqA=usfreq[dfrqA];
+           frqrngA=ufreq_range[dfrqA];
+        } else {
+           stfrqA=usfreq[nfrqA];
+           frqrngA=ufreq_range[nfrqA];
+        } 
+      } else {
+        stfrqA=usfreq[ifreqsAband];
+        frqrngA=ufreq_range[ifreqsAband];
+      }
+
+      if (day_nightB) { 
+        if (OpsDayNight()==1) {
+           stfrqB=usfreq[dfrqB];
+           frqrngB=ufreq_range[dfrqB];
+        } else {
+           stfrqB=usfreq[nfrqB];
+           frqrngB=ufreq_range[nfrqB];
+        } 
+      } else {
+        stfrqB=usfreq[ifreqsBband];
+        frqrngB=ufreq_range[ifreqsBband];
+      }
+
+      SiteSetChannel(CHN_B);
+      SiteSetBeam(bmnumB);
+      SiteSetChannel(CHN_A);
+      SiteSetBeam(bmnumA);
+ 
+      SiteSetIntt(intsc,intus);
+ 
+      if (SiteFCLRS(stfrqA,stfrqA+frqrngA,stfrqB,
+                    stfrqB+frqrngB)==FREQ_LOCAL)
+        ErrLog(errlog,progname,"Frequency Synthesizer in local mode.");
+
+      if (tfreqA==-1) tfreqA=ftable->dfrq;
+      if (tfreqB==-1) tfreqB=ftable->dfrq;
+
+      sprintf(logtxt,"Channel A Transmitting on: %d (Noise=%g)",tfreqA,noiseA);
+      ErrLog(errlog,progname,logtxt);
+
+      sprintf(logtxt,"Channel B Transmitting on: %d (Noise=%g)",tfreqB,noiseB);
+      ErrLog(errlog,progname,logtxt);
+
+      SiteSetChannel(CHN_A);
+      SiteSetFreq(tfreqA);
+      SiteSetChannel(CHN_B);
+      SiteSetFreq(tfreqB);
+
+	  sprintf(logtxt,"Integrating:%2d,%2d intt:%d (%02d:%02d:%02d) %5d (%02d)  %5d (%02d) - %s  %d\n",
+		      bmnumA, bmnumB, intsc, hr, mt, 
+              sc, tfreqA, ifreqsAband, tfreqB, ifreqsBband, 
+              OpsDayNight() ? "day" : "night", abs(tfreqA - tfreqB));
+
+      ErrLog(errlog,progname,logtxt);
+
+      u_read_uconts();
+
+      txplA = (rsepA * 20) / 3;
+      txplB = (rsepB * 20) / 3;
+
+      tsgidA=SiteTimeSeqS(0,ptab);
+      tsgidB=SiteTimeSeqS(1,ptab);
+
+      SiteIntegrateS(lags,lags);   
+   
+
+      if (naveA<0) {
+        sprintf(logtxt,"Integration A failed:%d",naveA);
+        ErrLog(errlog,progname,logtxt); 
+        continue;
+      }
+      if (naveB<0) {
+        sprintf(logtxt,"Integration B failed:%d",naveB);
+        ErrLog(errlog,progname,logtxt); 
+        continue;
+      }
+
+      sprintf(logtxt,"Number of sequences: %d %d",naveA,naveB);
+      ErrLog(errlog,progname,logtxt);
+
+      OpsBuildRawS(0,&prmA,&rawA,ptab,lags);
+      OpsBuildRawS(1,&prmB,&rawB,ptab,lags);
+
+      FitACF(&prmA,&rawA,&fblk,&fitA);
+      FitACF(&prmB,&rawB,&fblk,&fitB);
+
+      ErrLog(errlog,progname,"Sending messages."); 
+  
+
+      msg.num=0;
+      msg.tsize=0;
+
+      RMsgSndAdd(&msg,sizeof(struct RadarParm),(unsigned char *) &prmA,
+		PRM_TYPE,0); 
+      RMsgSndAdd(&msg,sizeof(struct RawData),(unsigned char *) &rawA,
+		RAW_TYPE,0);    
+
+      RMsgSndAdd(&msg,sizeof(struct FitData),(unsigned char *) &fitA,
+		FIT_TYPE,0);
+
+      RMsgSndAdd(&msg,strlen(progname)+1,progname,
+		NME_TYPE,0);   
+
+      RMsgSndAdd(&msg,sizeof(struct RadarParm),(unsigned char *) &prmB,
+		PRM_TYPE,1); 
+      RMsgSndAdd(&msg,sizeof(struct RawData),(unsigned char *) &rawB,
+		RAW_TYPE,1);    
+
+      RMsgSndAdd(&msg,sizeof(struct FitData),(unsigned char *) &fitB,
+		FIT_TYPE,1);
+
+   
+      RMsgSndAdd(&msg,strlen(progname)+1,progname,
+		NME_TYPE,1);   
+ 
+
+      for (n=0;n<tnum;n++) RMsgSndSend(tlist[n],&msg); 
+  
+      ErrLog(errlog,progname,"Polling for exit."); 
+ 
+      exitpoll=RadarShell(sid,&rstable);
+
+	  /* check the bands and beams here, after radar shell */
+
+	  RemInvalidBeams(ibeamsA, ibeamsB);			
+	  FindNumBeams(&numbeamsA, &numbeamsB, ibeamsA, ibeamsB, 0);
+
+	  RemInvalidEntries(ifreqsA, ifreqsB);
+	  FindNumBands(&numfreqbandsA, &numfreqbandsB, &day_nightA, &day_nightB, ifreqsA, ifreqsB, 0);
+
+	  if (ifreqsA_index >= numfreqbandsA) ifreqsA_index = 0;
+	  if (ifreqsB_index >= numfreqbandsB) ifreqsB_index = 0;
+  
+	  /* Calculate delay offsets if stereo offset has been changed
+         If stereo_offset is +ve A is later than B
+       */
+
+	  if (stereo_offset > 0) {
+	    delays[1] = 0;
+		delays[0] = stereo_offset / 10; /* stereo_offset is in usec */
+ 	  } else {
+		delays[0] = 0;
+		delays[1] = (stereo_offset / 10) * (-1); /* stereo_offset is in usec */
+	  }
+
+	  if (exitpoll !=0) break;
+
+	  scanA = 0;
+	  scanB = 0;
+
+	  /* change beam number index */
+
+	  ibeamsB_index++;
+
+	  if (ibeamsB_index >= numbeamsB) ibeamsB_index = 0;
+
+	  /* change band at the end of channel B scan */
+
+	  if (ibeamsB_index == 0) {
+	    if (numfreqbandsB != 0) {
+		  ifreqsB_index++;
+          if (ifreqsB_index >= numfreqbandsB) ifreqsB_index = 0;
+		}
+	  }
+    } 
+    
+	/* increment individual frequency band index. Doesn't matter whether
+	   individual frequency bands are being used for this channel or not.
+     */
+
+    if (numfreqbandsA != 0) {
+      ifreqsA_index++;
+      if (ifreqsA_index >= numfreqbandsA) ifreqsA_index = 0;
+    }
+
+    ErrLog(errlog,progname,"Waiting for scan boundary."); 
+    if ((scnsc !=0) || (scnus !=0)) {
+      if (exitpoll==0) OpsWaitBoundary(scnsc,scnus);
+    }
+  } while (exitpoll==0);
+  SiteEnd();
+  for (n=0;n<tnum;n++) RMsgSndClose(tlist[n]);
+  ErrLog(errlog,progname,"Ending program.");
+  RShellTerminate(sid);
+  return 0;   
+} 
+ 
+
+/***************************************************************************/
+
+/* Sets up the licenced frequency bands for Iceland & finland */
+
+void u_init_freq_bands() {
+
+/* start freq of each band */
+
+   /* Finland */
+
+   usfreq[0] = 8305;
+   usfreq[1] = 8965;
+   usfreq[2] = 9900;
+   usfreq[3] = 11075;
+   usfreq[4] = 11550;
+   usfreq[5] = 12370;
+   usfreq[6] = 13200;
+   usfreq[7] = 15010;
+   usfreq[8] = 16210;
+   usfreq[9] = 16555;
+   usfreq[10] = 17970;
+   usfreq[11] = 18850;
+   usfreq[12] = 19415;
+   usfreq[13] = 19705;
+   usfreq[14] = 19800;
+
+   /* Iceland */
+
+   usfreq[20] = 8000;
+   usfreq[21] = 8430;
+   usfreq[22] = 8985;
+   usfreq[23] = 10155;
+   usfreq[24] = 10655;
+   usfreq[25] = 11290;
+   usfreq[26] = 11475;
+   usfreq[27] = 12105;
+   usfreq[28] = 12305;
+   usfreq[29] = 12590;
+   usfreq[30] = 13360;
+   usfreq[31] = 13875;
+   usfreq[32] = 14400;
+   usfreq[33] = 15805;
+   usfreq[34] = 16500;
+   usfreq[35] = 16820;
+   usfreq[36] = 18175;
+   usfreq[37] = 18835;
+   usfreq[38] = 19910;
+   usfreq[39] = 10155;
+
+   /* width of each band */
+
+   /* Finland */
+
+   ufreq_range[0] = 30;
+   ufreq_range[1] = 75;
+   ufreq_range[2] = 85;
+   ufreq_range[3] = 200;
+   ufreq_range[4] = 50;
+   ufreq_range[5] = 45;
+   ufreq_range[6] = 60;
+   ufreq_range[7] = 70;
+   ufreq_range[8] = 150;
+   ufreq_range[9] = 60;
+   ufreq_range[10] = 80;
+   ufreq_range[11] = 15;
+   ufreq_range[12] = 265;
+   ufreq_range[13] = 50;
+   ufreq_range[14] = 190; 
+
+   /* Iceland */
+
+   ufreq_range[20] = 195;
+   ufreq_range[21] = 420;
+   ufreq_range[22] = 410;
+   ufreq_range[23] = 500;
+   ufreq_range[24] = 520;
+   ufreq_range[25] = 160;
+   ufreq_range[26] = 120;
+   ufreq_range[27] = 130;
+   ufreq_range[28] = 205;
+   ufreq_range[29] = 690;
+   ufreq_range[30] = 205;
+   ufreq_range[31] = 120;
+   ufreq_range[32] = 615;
+   ufreq_range[33] = 560;
+   ufreq_range[34] = 185;
+   ufreq_range[35] = 655;
+   ufreq_range[36] = 595;
+   ufreq_range[37] = 50;
+   ufreq_range[38] = 90;
+   ufreq_range[39] = 1020;
+}
+
+/* Sends a proxy message to the microcontroller monitoring 
+   task every beam.
+*/
+
+void u_read_uconts() {
+  if (uucont_proxy != 0) Trigger(uucont_proxy);
+}
+
+
+
+/* remove invalid entries in the frequency band lists */
+
+void RemInvalidEntries(int ifreqsA[NUMBANDS], int ifreqsB[NUMBANDS]) {
+  int i, j;
+
+  for (i = NUMBANDS - 1; i > 0; i--) {
+
+	/* if the preceding element is -1 then move all the following
+	   bands down
+     */
+
+	if ((ifreqsA[i] != -1) && (ifreqsA[i - 1] == -1)) {
+	  for (j = i; j < NUMBANDS; j++) {
+	    ifreqsA[j - 1] = ifreqsA[j];
+		ifreqsA[j] = -1;
+	  }
+	}
+
+	if ((ifreqsB[i] != -1) && (ifreqsB[i - 1] == -1)) {
+	  for (j = i; j < NUMBANDS; j++) {
+	    ifreqsB[j - 1] = ifreqsB[j];
+		ifreqsB[j] = -1;
+	  }
+	}
+  }
+}
+
+/* determine the number of frequency bands */
+
+void FindNumBands(int *numfreqbandsA, int *numfreqbandsB, 
+                  int *day_nightA, int *day_nightB, 
+                  int ifreqsA[NUMBANDS], int ifreqsB[NUMBANDS], 
+                  int print) {
+  int i;
+  char logtxt[256];
+
+  *numfreqbandsA = 0;
+  *numfreqbandsB = 0;
+
+  for (i = 0; i < NUMBANDS; i++) {
+    if (ifreqsA[i] != -1) (*numfreqbandsA)++;
+	if (ifreqsB[i] != -1) (*numfreqbandsB)++;
+  }
+
+  /* check to see if day/night frequencies are to be used */
+
+  if (*numfreqbandsA != 0) *day_nightA = 0;
+  else *day_nightA = 1;
+
+  if (*numfreqbandsB != 0) *day_nightB = 0;
+  else *day_nightB = 1;
+
+  if (print) {
+    sprintf(logtxt, "Channel A: %d  Channel B: %d", *numfreqbandsA, 
+            *numfreqbandsB);
+	ErrLog(errlog, progname, logtxt);
+  }
+
+  /* print frequency bands for each channel */
+
+  if ((*numfreqbandsA > 0) && print) {
+    ErrLog(errlog,progname,"Frequency bands for channel A: ");
+
+    for (i = 0; i < *numfreqbandsA; i++) {
+	  sprintf(logtxt, "%1d ", ifreqsA[i]);
+	  ErrLog(errlog,progname,logtxt);
+	}
+  }
+
+  if ((*numfreqbandsB > 0) && print) {
+    ErrLog(errlog,progname,"Frequency bands for channel B: ");
+
+	for (i = 0; i < *numfreqbandsB; i++) {
+	  sprintf(logtxt, "%1d ", ifreqsB[i]);
+	  ErrLog(errlog,progname,logtxt);
+	}
+  }
+}
+
+/* remove invalid entries in the beam lists */
+
+void RemInvalidBeams(int ibeamsA[NUMBEAMS], int ibeamsB[NUMBEAMS]) {
+  int i, j;
+
+  for (i = NUMBEAMS - 1; i > 0; i--) {
+    if (ibeamsA[i] <  0) ibeamsA[i] = -1;
+	if (ibeamsA[i] > 15) ibeamsA[i] = -1;
+
+	if (ibeamsB[i] <  0) ibeamsB[i] = -1;
+	if (ibeamsB[i] > 15) ibeamsB[i] = -1;
+  }
+
+  for (i = NUMBEAMS - 1; i > 0; i--) {
+
+	/* if the preceding element is -1 then move all the 
+       following beams down
+     */
+
+	if ((ibeamsA[i - 1] == -1) && (ibeamsA[i] != -1)) {
+	  for (j = i; j < NUMBEAMS; j++) {
+	    ibeamsA[j - 1] = ibeamsA[j];
+		ibeamsA[j] = -1;
+	  }
+	}
+
+	if ((ibeamsB[i - 1] == -1) && (ibeamsB[i] != -1)) {
+	  for (j = i; j < NUMBEAMS; j++) {
+	    ibeamsB[j - 1] = ibeamsB[j];
+		ibeamsB[j] = -1;
+	  }
+	}
+  }
+}
+
+/* determine the number of beams */
+
+void FindNumBeams(int *numbeamsA, int *numbeamsB, 
+                  int ibeamsA[NUMBEAMS], int ibeamsB[NUMBEAMS], 
+                  int print) {
+  int i;
+  char logtxt[256];
+
+  *numbeamsA = 0;
+  *numbeamsB = 0;
+
+  /* count channel A beams */
+
+  for (i = 0; i < NUMBEAMS; i++) {
+    if (ibeamsA[i] != -1) (*numbeamsA)++;
+	else break;
+  }
+
+  /* count channel B beams */
+
+  for (i = 0; i < NUMBEAMS; i++) {
+    if (ibeamsB[i] != -1) (*numbeamsB)++;
+	else break;
+  }
+
+  if (print) {
+    sprintf(logtxt, "Beams A: %d  Beams B: %d", *numbeamsA, *numbeamsB);
+	ErrLog(errlog, progname, logtxt);
+
+	/* print frequency bands for each channel */
+
+	if (*numbeamsA > 0) {
+	  ErrLog(errlog,progname,"Beams for channel A: ");
+
+	  for (i = 0; i < *numbeamsA; i++) {
+	    sprintf(logtxt, "%1d ", ibeamsA[i]);
+	    ErrLog(errlog,progname,logtxt);
+	  }
+	}
+
+	if (*numbeamsB > 0) {
+	  ErrLog(errlog,progname,"Beams for channel B: ");
+       for (i = 0; i < *numbeamsB; i++) {
+	     sprintf(logtxt, "%1d ", ibeamsB[i]);
+		 ErrLog(errlog,progname,logtxt);
+	   }
+	}
+  }
+
+  /* if no beams have been specified fill the arrays with normal sequence
+     between low_beam and high beam.  
+   */
+  
+  if (*numbeamsA == 0) {
+    if (backward) {
+      for (i = 0; i < (high_beam_A - low_beam_A + 1); i++) {
+        ibeamsA[i] = high_beam_A - i;
+        (*numbeamsA)++;
+ 	  }
+    } else {
+ 	  for (i = 0; i < (high_beam_A - low_beam_A + 1); i++) {
+	    ibeamsA[i] = low_beam_A + i;
+        (*numbeamsA)++;
+	  }
+    }
+  }
+
+  if (*numbeamsB == 0) {
+
+	if (backward) {
+      for (i = 0; i < (high_beam_B - low_beam_B + 1); i++) {
+  	    ibeamsB[i] = high_beam_B - i;
+        (*numbeamsB)++;
+	  }
+    } else {
+  	  for (i = 0; i < (high_beam_B - low_beam_B + 1); i++) {
+        ibeamsB[i] = low_beam_B + i;
+        (*numbeamsB)++;
+	  }
+    }
+  }
+}
+
+
+
+

--- a/qnx4/sd_leicester/han/stereoscan.1.04/version.info
+++ b/qnx4/sd_leicester/han/stereoscan.1.04/version.info
@@ -1,0 +1,15 @@
+# $Log: version.info,v $
+# Revision 1.4  2007/08/09 14:10:26  code
+# Added the ability to pass command line options as a file.
+#
+# Revision 1.3  2007/08/08 16:56:07  code
+# Fixed bug in using hex notation for stid.
+#
+# Revision 1.2  2006/07/12 15:51:55  code
+# Added call to set up command line and limited data written to rawacf and fitacf.
+#
+# Revision 1.1  2006/03/30 11:28:25  barnes
+# Initial revision
+#
+#
+stereoscan.c 1.04

--- a/qnx4/sd_leicester/pyk/normalscan.1.08/makefile
+++ b/qnx4/sd_leicester/pyk/normalscan.1.08/makefile
@@ -1,0 +1,44 @@
+# Makefile for tauscan
+# =======================
+# by R.J.Barnes
+#
+#
+
+
+INCLUDE=-I$(IPATH)/base -I$(IPATH)/general -I$(IPATH)/superdarn \
+	-I$(IPATH)/radarqnx4 \
+	-I$(USR_IPATH)/radarqnx4/ops \
+	-I$(USR_IPATH)/radarqnx4/site.$(SD_RADARCODE)
+
+OBJS = normalscan.o
+SRC=normalscan.c
+IGNVER=1
+OUTPUT = $(USR_BINPATH)/normalscan
+SUDO = 1 
+LIBS=-lsite.${SD_RADARCODE}.1 -lops.1 -lfitacf.1 -lradar.1 -lerrlog.1 \
+      -lrs.1 -lfreq.1 -lacf.1 -ltcpipmsg.1 -lrawfeed.1 -ltsg.1  \
+      -ltaskid.1 -lrmsgsnd.1 -lrtimer.1 -lrtime.1 -lrmath.1 -lopt.1 
+include $(SITELIB).${SD_RADARCODE}
+include $(MAKEBIN)
+
+
+
+
+
+
+  
+
+
+
+
+
+
+
+
+
+  
+
+
+ 
+
+

--- a/qnx4/sd_leicester/pyk/normalscan.1.08/makefile.bak
+++ b/qnx4/sd_leicester/pyk/normalscan.1.08/makefile.bak
@@ -1,0 +1,48 @@
+# Makefile for tauscan
+# =======================
+# by R.J.Barnes
+#
+#
+
+
+INCLUDE=-I$(IPATH)/base -I$(IPATH)/general -I$(IPATH)/superdarn \
+	-I$(IPATH)/radarqnx4 \
+	-I$(USR_IPATH)/radarqnx4/ops \
+	-I$(USR_IPATH)/radarqnx4/site.$(SD_RADARCODE)
+
+OBJS = normalscan.o
+SRC=normalscan.c
+IGNVER=1
+OUTPUT = $(USR_BINPATH)/normalscan
+SUDO = 1 
+LIBS=-lsite.${SD_RADARCODE}.1 -lops.1 -lfitacf.1 -lradar.1 -lerrlog.1 \
+     -lfclr.1 -lfclrgc214.1 -lfclrs.1 \
+     -lintegrate.1 -lintegrategc214.1 -lintegrategc214ex.1 \
+     -lintegrates.1 -lrs.1 -lfreq.1 \
+     -lacf.1 -lacfex.1 -lgc214.1 -lad.1 -ldio.1 \
+     -ltcpipmsg.1 -lrawfeed.1 -ltsg.1  \
+     -ltaskid.1 -lrmsgsnd.1 -lrtimer.1 -lrtime.1 -lrmath.1 -lopt.1 
+SLIB=-lm
+include $(MAKEBIN)
+
+
+
+
+
+
+  
+
+
+
+
+
+
+
+
+
+  
+
+
+ 
+
+

--- a/qnx4/sd_leicester/pyk/normalscan.1.08/normalscan.c
+++ b/qnx4/sd_leicester/pyk/normalscan.1.08/normalscan.c
@@ -1,0 +1,394 @@
+/* normalscan.c
+   ============
+   Author: R.J.Barnes
+*/
+
+/*
+ Copyright 2004 The Johns Hopkins University/Applied Physics Laboratory.
+ All rights reserved.
+ 
+ This material may be used, modified, or reproduced by or for the U.S.
+ Government pursuant to the license rights granted under the clauses at DFARS
+ 252.227-7013/7014.
+ 
+ For any other permissions, please contact the Space Department
+ Program Office at JHU/APL.
+ 
+ This Distribution and Disclaimer Statement must be included in all copies of
+ "Radar Operating System - Control Programs" (hereinafter "the Program").
+ 
+ The Program was developed at The Johns Hopkins University/Applied Physics
+ Laboratory (JHU/APL) which is the author thereof under the "work made for
+ hire" provisions of the copyright law.  
+ 
+ JHU/APL assumes no obligation to provide support of any kind with regard to
+ the Program.  This includes no obligation to provide assistance in using the
+ Program or to provide updated versions of the Program.
+ 
+ THE PROGRAM AND ITS DOCUMENTATION ARE PROVIDED AS IS AND WITHOUT ANY EXPRESS
+ OR IMPLIED WARRANTIES WHATSOEVER.  ALL WARRANTIES INCLUDING, BUT NOT LIMITED
+ TO, PERFORMANCE, MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE ARE
+ HEREBY DISCLAIMED.  YOU ASSUME THE ENTIRE RISK AND LIABILITY OF USING THE
+ PROGRAM TO INCLUDE USE IN COMPLIANCE WITH ANY THIRD PARTY RIGHTS.  YOU ARE
+ ADVISED TO TEST THE PROGRAM THOROUGHLY BEFORE RELYING ON IT.  IN NO EVENT
+ SHALL JHU/APL BE LIABLE FOR ANY DAMAGES WHATSOEVER, INCLUDING, WITHOUT
+ LIMITATION, ANY LOST PROFITS, LOST SAVINGS OR OTHER INCIDENTAL OR
+ CONSEQUENTIAL DAMAGES, ARISING OUT OF THE USE OR INABILITY TO USE THE
+ PROGRAM."
+ 
+ 
+ 
+ 
+ 
+ 
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/types.h>
+#include <string.h>
+#include <time.h>
+#include "rtypes.h"
+#include "option.h"
+#include "rtime.h"
+#include "limit.h"
+#include "radar.h"
+#include "rprm.h"
+#include "rawdata.h"
+#include "fitblk.h"
+#include "fitdata.h"
+#include "fitacf.h"
+
+
+#include "taskid.h"
+#include "errlog.h"
+#include "rmsg.h"
+#include "radarshell.h"
+#include "rmsgsnd.h"
+#include "tsg.h"
+#include "tsgtable.h"
+#include "maketsg.h"
+#include "global.h"
+#include "setup.h"
+#include "reopen.h"
+#include "tmseq.h"
+#include "raw.h"
+#include "sync.h"
+#include "interface.h"
+#include "hdw.h"
+
+/*
+ $Log: normalscan.c,v $
+ Revision 1.8  2006/07/12 15:48:23  code
+ Added call to set up command line and limited data written to rawacf and fitacf.
+
+ Revision 1.7  2006/02/07 20:55:06  barnes
+ Simon Shepherd's modification to the lag table.
+
+ Revision 1.6  2006/02/07 17:50:17  barnes
+ Fixed bug in calling Errlog.
+
+ Revision 1.5  2006/02/07 17:43:41  barnes
+ Dieter Andre's modification to make integration errors less mysterious.
+
+ Revision 1.4  2005/08/01 18:18:47  barnes
+ Fixed incorrect command line option.
+
+ Revision 1.3  2005/07/19 15:26:59  barnes
+ Added Dieter Andre's extra command line options.
+
+ Revision 1.2  2004/07/23 15:48:27  barnes
+ Fixed bug in beam swinging direction.
+
+ Revision 1.1  2004/05/11 17:43:22  barnes
+ Initial revision
+ 
+*/
+
+#define SCHEDULER "schedule"
+#define ERRLOG "errlog"
+
+#define CONTROL_NAME "control_program"
+#define TASK_NAMES "echo_data","rawacfwrite","fitacfwrite"
+
+char cmdlne[1024];
+char progid[80]={"$Id: normalscan.c,v 1.8 2006/07/12 15:48:23 code Exp $"};
+char progname[256];
+struct TaskID *errlog;
+
+char *tasklist[]=
+ { TASK_NAMES,
+  0};
+
+int arg=0;
+struct OptionData opt;
+      
+int main(int argc,char *argv[]) {
+
+  int ptab[8] = {0,14,22,24,27,31,42,43};
+
+  int lags[LAG_SIZE][2] = {
+    { 0, 0},		/*  0 */
+    {42,43},		/*  1 */
+    {22,24},		/*  2 */
+    {24,27},		/*  3 */
+    {27,31},		/*  4 */
+    {22,27},		/*  5 */
+
+    {24,31},		/*  7 */
+    {14,22},		/*  8 */
+    {22,31},		/*  9 */
+    {14,24},		/* 10 */
+    {31,42},		/* 11 */
+    {31,43},		/* 12 */
+    {14,27},		/* 13 */
+    { 0,14},		/* 14 */
+    {27,42},		/* 15 */
+    {27,43},		/* 16 */
+    {14,31},		/* 17 */
+    {24,42},		/* 18 */
+    {24,43},		/* 19 */
+    {22,42},		/* 20 */
+    {22,43},		/* 21 */
+    { 0,22},		/* 22 */
+
+    { 0,24},		/* 24 */
+
+    {43,43}};		/* alternate lag-0  */
+
+
+  char *sname=NULL;
+  char *ename=NULL;
+  char *sdname={SCHEDULER};
+  char *edname={ERRLOG};
+  char logtxt[1024];
+
+  int n;
+  pid_t sid;
+  int exitpoll=0;
+ 
+  int scnsc=120;
+  int scnus=0;
+  int skip;
+  int cnt=0;
+
+  unsigned char fast=0;
+  unsigned char discretion=0;
+
+  strcpy(cmdlne,argv[0]);
+  for (n=1;n<argc;n++) {
+    strcat(cmdlne," ");
+    strcat(cmdlne,argv[n]);
+  } 
+
+  strncpy(combf,progid,80);   
+  OpsSetupCommand(argc,argv);
+  OpsSetupRadar();
+  OpsSetupShell();
+   
+  RadarShellParse(&rstable,"sbm l ebm l dfrq l nfrq l dfrang l nfrang l dmpinc l nmpinc l frqrng l xcnt l",                        
+                  &sbm,&ebm,                              
+                  &dfrq,&nfrq,                  
+                  &dfrang,&nfrang,                            
+                  &dmpinc,&nmpinc,                            
+                  &frqrng,&xcnt);        
+
+  cp=150;
+  intsc=7;
+  intus=0;
+  mppul=8;
+  mplgs=23;
+  mpinc=1500;
+  dmpinc=1500;
+  nrang=75;
+  rsep=45;
+  txpl=300;
+
+  SiteStart();
+
+  /* ========= PROCESS COMMAND LINE ARGUMENTS ============= */
+
+
+  OptionAdd(&opt,"di",'x',&discretion);
+
+
+  OptionAdd(&opt,"el",'t',&ename);
+  OptionAdd(&opt,"sc",'t',&sname);
+
+  OptionAdd(&opt,"frang",'i',&frang);
+  OptionAdd(&opt,"rsep",'i',&rsep);
+
+  OptionAdd( &opt, "dt", 'i', &day);
+  OptionAdd( &opt, "nt", 'i', &night);
+  OptionAdd( &opt, "df", 'i', &dfrq);
+  OptionAdd( &opt, "nf", 'i', &nfrq);
+  OptionAdd( &opt, "xcf", 'i', &xcnt);
+ 
+  OptionAdd(&opt,"fast",'x',&fast);
+ 
+
+
+  
+  arg=OptionProcess(1,argc,argv,&opt,NULL);  
+ 
+  if (sname==NULL) sname=sdname;
+  if (ename==NULL) ename=edname;
+
+  sid=RShellRegister(sname,CONTROL_NAME);
+
+  errlog=TaskIDMake(ename);  
+  OpsLogStart(errlog,progname,argc,argv);  
+
+  SiteSetupHardware();
+
+  if (fast) {
+     cp=151;
+     scnsc=60;
+     scnus=0;
+     intsc=3;
+     intus=0;
+  }
+
+  if ( discretion) cp= -cp;
+
+  txpl=(rsep*20)/3;
+
+  if (fast) sprintf(progname,"normalscan (fast)");
+  else sprintf(progname,"normalscan");
+
+  OpsFitACFStart();
+
+  OpsSetupTask(tasklist);
+  for (n=0;n<tnum;n++) {
+    RMsgSndReset(tlist[n]);
+    RMsgSndOpen(tlist[n],strlen(cmdlne),cmdlne);     
+  }
+
+  do {
+
+    if (SiteStartScan()==0) continue;
+
+    if (OpsReOpen(2,0,0) !=0) {
+      ErrLog(errlog,progname,"Opening new files.");
+      for (n=0;n<tnum;n++) {
+        RMsgSndClose(tlist[n]);
+        RMsgSndOpen(tlist[n],strlen(cmdlne),cmdlne);     
+      }
+    }
+
+    scan=1;
+
+    ErrLog(errlog,progname,"Starting scan.");
+
+    if (xcnt>0) {
+      cnt++;
+      if (cnt==xcnt) {
+        xcf=1;
+        cnt=0;
+      } else xcf=0;
+    } else xcf=0;
+
+    skip=OpsFindSkip(scnsc,scnus);
+
+    if (backward) {
+      bmnum=sbm-skip;
+      if (bmnum<ebm) bmnum=sbm;
+    } else {
+      bmnum=sbm+skip;
+      if (bmnum>ebm) bmnum=sbm;
+    }
+
+    do {
+
+      TimeReadClock(&yr,&mo,&dy,&hr,&mt,&sc,&us);
+ 
+      if (OpsDayNight()==1) {
+        stfrq=dfrq;
+        mpinc=dmpinc;
+        frang=dfrang;
+      } else {
+        stfrq=nfrq;
+        mpinc=nmpinc;
+        frang=nfrang;
+      }        
+
+      sprintf(logtxt,"Integrating beam:%d intt:%ds.%dus (%d:%d:%d:%d)",bmnum,
+                      intsc,intus,hr,mt,sc,us);
+      ErrLog(errlog,progname,logtxt);
+
+      ErrLog(errlog,progname,"Setting beam.");
+
+      SiteSetIntt(intsc,intus);
+      SiteSetBeam(bmnum);
+
+      ErrLog(errlog,progname,"Doing clear frequency search."); 
+   
+      sprintf(logtxt, "FRQ: %d %d", stfrq, frqrng);
+      ErrLog( errlog, progname, logtxt);
+
+      if (SiteFCLR(stfrq,stfrq+frqrng)==FREQ_LOCAL)
+        ErrLog(errlog,progname,"Frequency Synthesizer in local mode.");
+
+      SiteSetFreq(tfreq);
+
+      sprintf(logtxt,"Transmitting on: %d (Noise=%g)",tfreq,noise);
+
+      ErrLog(errlog,progname,logtxt);
+
+      tsgid=SiteTimeSeq(ptab);
+
+      nave=SiteIntegrate(lags);   
+      if (nave<0) {
+        sprintf(logtxt,"Integration error:%d",nave);
+        ErrLog(errlog,progname,logtxt); 
+        continue;
+      }
+      sprintf(logtxt,"Number of sequences: %d",nave);
+      ErrLog(errlog,progname,logtxt);
+
+
+      OpsBuildRaw(&prm,&raw,ptab,lags);
+
+      FitACF(&prm,&raw,&fblk,&fit);
+
+      ErrLog(errlog,progname,"Sending messages."); 
+  
+
+      msg.num=0;
+      msg.tsize=0;
+
+      RMsgSndAdd(&msg,sizeof(struct RadarParm),(unsigned char *) &prm,
+		PRM_TYPE,0); 
+      RMsgSndAdd(&msg,sizeof(struct RawData),(unsigned char *) &raw,
+		RAW_TYPE,0);    
+
+      RMsgSndAdd(&msg,sizeof(struct FitData),(unsigned char *) &fit,
+		FIT_TYPE,0);   
+      RMsgSndAdd(&msg,strlen(progname)+1,progname,
+		NME_TYPE,0);   
+ 
+
+      for (n=0;n<tnum;n++) RMsgSndSend(tlist[n],&msg); 
+  
+      ErrLog(errlog,progname,"Polling for exit."); 
+    
+      exitpoll=RadarShell(sid,&rstable);
+      if (exitpoll !=0) break;
+      scan=0;
+      if (bmnum==ebm) break;
+      if (backward) bmnum--;
+      else bmnum++;
+
+    } while (1);
+    ErrLog(errlog,progname,"Waiting for scan boundary."); 
+  
+    if (exitpoll==0) OpsWaitBoundary(scnsc,scnus);
+
+  } while (exitpoll==0);
+  SiteEnd();
+  for (n=0;n<tnum;n++) RMsgSndClose(tlist[n]);
+  ErrLog(errlog,progname,"Ending program.");
+  RShellTerminate(sid);
+  return 0;   
+} 
+ 

--- a/qnx4/sd_leicester/pyk/normalscan.1.08/version.info
+++ b/qnx4/sd_leicester/pyk/normalscan.1.08/version.info
@@ -1,0 +1,27 @@
+# $Log: version.info,v $
+# Revision 1.8  2006/07/12 15:49:23  code
+# Set up command line.
+#
+# Revision 1.7  2006/02/07 20:56:42  barnes
+# Simon Shepherd's modification to the lag table.
+#
+# Revision 1.6  2006/02/07 17:50:39  barnes
+# Fixed bug in calling Errlog.
+#
+# Revision 1.5  2006/02/07 17:44:14  barnes
+# Dieter Andre's modification to make integration errors less mysterious.
+#
+# Revision 1.4  2005/08/01 18:19:06  barnes
+# Fixed incorrect command line option.
+#
+# Revision 1.3  2005/07/19 15:27:19  barnes
+# Added Dieter Andre's extra command line options.
+#
+# Revision 1.2  2004/07/23 15:49:01  barnes
+# Fixed bug in beam swinging direction.
+#
+# Revision 1.1  2004/05/11 17:43:44  barnes
+# Initial revision
+#
+#
+normalscan.c 1.08

--- a/qnx4/sd_leicester/pyk/normalsound.2.05/makefile
+++ b/qnx4/sd_leicester/pyk/normalsound.2.05/makefile
@@ -1,0 +1,44 @@
+# Makefile for tauscan
+# =======================
+# by R.J.Barnes
+#
+#
+
+
+INCLUDE=-I$(IPATH)/base -I$(IPATH)/general -I$(IPATH)/superdarn \
+	-I$(IPATH)/radarqnx4 \
+	-I$(USR_IPATH)/radarqnx4/ops \
+	-I$(USR_IPATH)/radarqnx4/site.$(SD_RADARCODE)
+
+OBJS = normalsound.o
+SRC=normalsound.c
+IGNVER=1
+OUTPUT = $(USR_BINPATH)/normalsound
+SUDO = 1 
+LIBS=-lsite.${SD_RADARCODE}.1 -lops.1 -lfitacf.1 -lradar.1 -lerrlog.1 \
+      -lrs.1 -lfreq.1 -lacf.1 -ltcpipmsg.1 -lrawfeed.1 -ltsg.1  \
+      -ltaskid.1 -lrmsgsnd.1 -lrtimer.1 -lrtime.1 -lrmath.1 -lopt.1 
+include $(SITELIB).${SD_RADARCODE}
+include $(MAKEBIN)
+
+
+
+
+
+
+  
+
+
+
+
+
+
+
+
+
+  
+
+
+ 
+
+

--- a/qnx4/sd_leicester/pyk/normalsound.2.05/normalsound.c
+++ b/qnx4/sd_leicester/pyk/normalsound.2.05/normalsound.c
@@ -1,0 +1,966 @@
+/* normalsound.c
+   ============
+   Author: Dieter Andre
+*/
+
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/types.h>
+#include <string.h>
+#include <time.h>
+#include <env.h>
+#include <math.h>
+#include "rtypes.h"
+#include "option.h"
+#include "rtime.h"
+#include "limit.h"
+#include "radar.h"
+#include "rprm.h"
+#include "rawdata.h"
+#include "fitblk.h"
+#include "fitdata.h"
+#include "fitacf.h"
+
+
+#include "taskid.h"
+#include "errlog.h"
+#include "rmsg.h"
+#include "radarshell.h"
+#include "rmsgsnd.h"
+#include "tsg.h"
+#include "tsgtable.h"
+#include "maketsg.h"
+#include "global.h"
+#include "setup.h"
+#include "reopen.h"
+#include "tmseq.h"
+#include "raw.h"
+#include "sync.h"
+#include "interface.h"
+#include "hdw.h"
+
+/*
+ $Log: normalsound.c,v $
+ Revision 2.5  2006/07/12 15:50:19  code
+ Added call to set up command line and limited data written to rawacf and fitacf.
+
+ Revision 2.4  2006/04/13 18:14:36  barnes
+ Incorporated Dieter Andre's bug fix.
+
+ Revision 2.3  2006/02/07 20:55:52  barnes
+ Simon Shepherd's modification to the lag table.
+
+ Revision 2.2  2006/02/07 17:50:57  barnes
+ Added Dieter Andre's improved error logging.
+
+ Revision 2.1  2005/07/19 18:43:54  barnes
+ First revision included in the ROS 1.08.
+
+
+ Revision 2.0  2004/03/23 andre
+ Initial revision from John Hughes program
+ 
+*/
+
+/*======================================================================*/
+/* Program Description:							*/
+/* This version of normalsound runs under ROS 1.08			*/
+/* If you want to run fastsound just run normalsound -fast		*/
+/*									*/
+/* normalsound performs a scan through all 16 beams at 6s or 3s		*/
+/* integration time. In the remaining time until the end of the minute	*/
+/* it performs scans through a set of up to 12 frequencies and through	*/
+/* all beams [even/odd]. This is used to determine the frequency which	*/
+/* gives the most ionospheric scatter from time to time [default 15min]	*/
+/*									*/
+/* The file $SD_HDWPATH/sounder.dat shoudl contain the following values	*/
+/* one per line:							*/
+/* Time between frequency evaluations [min]				*/
+/* Number of sounder frequencies					*/
+/* The sounder frequencies [kHz]					*/
+/*									*/
+/* If this file does not exist, default values are used. This is not a	*/
+/* good idea, as the program may try to sound at forbidden frequencies.	*/
+/*									*/
+/* The sounding data are writen to *.snd files, for each beam one	*/
+/* header and a data record for each good [qflg=1] range.		*/
+/* We have decided to do away with the internal compression, since we	*/
+/* feel, that zipping the files afterwards gives the same result.	*/
+/*									*/
+/* The information used to determine the optimal frequency is kept in	*/
+/* an internal circular buffer, that can hold 1 hour of data. This way	*/
+/* we avoid having to read the files each 15 minutes or so.		*/
+/*									*/
+/* At the moment the whole buffer is used to calculate for each beam	*/
+/* and each sounder frequency :						*/
+/* ( #total_returns - #groundscatter_returns)/ #ranges			*/
+/* These values are then averaged over all beams and if the maximum	*/
+/* gives a sufficient improvement over the presently used one, the	*/
+/* frequency is switched [ see find_optimal_freq for details]		*/
+/*======================================================================*/
+
+#define SCHEDULER "schedule"
+#define ERRLOG "errlog"
+
+#define CONTROL_NAME "control_program"
+#define TASK_NAMES "echo_data","rawacfwrite","fitacfwrite"
+
+char cmdlne[1024];
+char progid[80]={"$Id: normalsound.c,v 2.5 2006/07/12 15:50:19 code Exp $"};
+char progname[256];
+struct TaskID *errlog;
+
+char *tasklist[]=
+ { TASK_NAMES,
+  0};
+
+int arg=0;
+struct OptionData opt;
+
+/* used by cutlass radars */
+/* extern int lsfreq[], lfreq_range[]; */
+
+/* Up to 1 hour of sounding data is stored in this structure */
+
+/* 24* 30/ sounder_intt */
+#define NUM_SND_DATA 360
+#define SND_NRANG 75
+#define SND_NBM 16
+#define SND_NFBIN 26
+#define MAX_SND_FREQS 12
+
+struct sounder_struct
+  {
+  double stime;
+  char program_name[40];
+  int site_id;
+  int beam_num;
+  int freq;
+  int noise;
+  int frange;
+  int rsep;
+  float pwr[ SND_NRANG];
+  float vel[ SND_NRANG];
+  float width[ SND_NRANG];
+  float  AOA[ SND_NRANG];
+  int gsct[ SND_NRANG];
+  int qflg[ SND_NRANG];
+  };
+
+      
+int main(int argc,char *argv[]) {
+
+  int ptab[8] = {0,14,22,24,27,31,42,43};
+
+  int lags[LAG_SIZE][2] = {
+    { 0, 0},    /*  0 */
+    {42,43},    /*  1 */
+    {22,24},    /*  2 */
+    {24,27},    /*  3 */
+    {27,31},    /*  4 */
+    {22,27},    /*  5 */
+
+    {24,31},    /*  7 */
+    {14,22},    /*  8 */
+    {22,31},    /*  9 */
+    {14,24},    /* 10 */
+    {31,42},    /* 11 */
+    {31,43},    /* 12 */
+    {14,27},    /* 13 */
+    { 0,14},    /* 14 */
+    {27,42},    /* 15 */
+    {27,43},    /* 16 */
+    {14,31},    /* 17 */
+    {24,42},    /* 18 */
+    {24,43},    /* 19 */
+    {22,42},    /* 20 */
+    {22,43},    /* 21 */
+    { 0,22},    /* 22 */
+
+    { 0,24},    /* 24 */
+
+    {43,43}};   /* alternate lag-0  */
+
+
+
+  char *sname=NULL;
+  char *ename=NULL;
+  char *sdname={SCHEDULER};
+  char *edname={ERRLOG};
+  char logtxt[1024];
+
+  int n;
+  pid_t sid;
+  int exitpoll=0;
+ 
+  int scnsc=120;
+  int scnus=0;
+  int skip;
+  int cnt=0;
+
+  unsigned char fast=0;
+  unsigned char discretion=0;
+
+  /* Variables for sounding */
+  char snd_filename[ 100];
+  FILE *snd_dat;
+  /* If the file $SD_HDWPATH/sounder.dat exists, the next three parameters are read from it */
+  /* the file contains one integer value per line */
+  int freq_dwell=15; /* after so many minutes a new optimal frequency is evaluated */
+  int sounder_freqs_total=8;
+  int sounder_freqs[ MAX_SND_FREQS]= { 11000, 12000, 13000, 14000, 15000, 16000, 17000, 18000, 0, 0, 0, 0 };
+  time_t last_freq_search, t_now;
+  int fw=0; // frequency weighting flag used in selecting the optimal freq
+  int sounder_beams[]={0,2,4,6,8,10,12,14};
+  int sounder_freq_count=0, sounder_beam_count=0;
+  int sounder_beams_total=8, odd_beams=0;
+  int sounder_freq;
+  int sounder_beam_loop=1;
+  int normal_intt=6;
+  int fast_intt=3;
+  int sounder_intt=2; 
+  int do_new_freq_search=0;
+  float sounder_time, time_needed=1.25;
+  int cutlass=0;
+  struct sounder_struct *sounder_data;
+  int act_snd_rec= 0;
+  
+  sprintf( snd_filename,"%s/sounder.dat", getenv("SD_HDWPATH"));
+  snd_dat= fopen( snd_filename, "r");
+  if( snd_dat != NULL ) {
+    fscanf( snd_dat, "%d", &freq_dwell);
+    fscanf( snd_dat, "%d", &sounder_freqs_total);
+    if (sounder_freqs_total > 12) sounder_freqs_total= 12;
+    for ( sounder_freq_count=0; sounder_freq_count < sounder_freqs_total; sounder_freq_count++ )
+      fscanf( snd_dat, "%d", &sounder_freqs[ sounder_freq_count] );
+    sounder_freq_count= 0;
+    fclose( snd_dat);
+  }
+
+  
+  sounder_data= ( struct sounder_struct *) calloc( sizeof( struct sounder_struct), NUM_SND_DATA);
+  
+  strcpy(cmdlne,argv[0]);
+  for (n=1;n<argc;n++) {
+    strcat(cmdlne," ");
+    strcat(cmdlne,argv[n]);
+  } 
+
+  strncpy(combf,progid,80);   
+  OpsSetupCommand(argc,argv);
+  OpsSetupRadar();
+  OpsSetupShell();
+   
+  RadarShellParse(&rstable,"sbm l ebm l dfrq l nfrq l dfrang l nfrang l dmpinc l nmpinc l frqrng l xcnt l",                        
+                  &sbm,&ebm,                              
+                  &dfrq,&nfrq,                  
+                  &dfrang,&nfrang,                            
+                  &dmpinc,&nmpinc,                            
+                  &frqrng,&xcnt);        
+
+  cp=155; /* normalsound */
+  intsc= normal_intt;
+  intus=0;
+  mppul=8;
+  mplgs=23;
+  mpinc=1500;
+  dmpinc=1500;
+  nrang=75;
+  rsep=45;
+  txpl=300;
+
+  SiteStart();
+  /* need to find out whether this is a CUTLASS-type radar */
+  if( getenv("CUTLASS_ADDRESS")==NULL ) cutlass=0;
+  else cutlass=1;
+
+  /* ========= PROCESS COMMAND LINE ARGUMENTS ============= */
+
+  OptionAdd(&opt,"el",'t',&ename);
+  OptionAdd(&opt,"sc",'t',&sname);
+
+  OptionAdd( &opt, "di", 'x', &discretion);
+  OptionAdd( &opt, "dt", 'i', &day);
+  OptionAdd( &opt, "nt", 'i', &night);
+  OptionAdd( &opt, "df", 'i', &dfrq);
+  OptionAdd( &opt, "nf", 'i', &nfrq);
+  OptionAdd( &opt,"dr",  'i', &dfrang);
+  OptionAdd( &opt,"nr",  'i', &nfrang);
+  OptionAdd( &opt, "dm", 'i', &dmpinc);
+  OptionAdd( &opt, "nm", 'i', &nmpinc);
+  OptionAdd( &opt, "sb", 'i', &sbm);
+  OptionAdd( &opt, "eb", 'i', &ebm);
+  OptionAdd( &opt, "xcf", 'i', &xcnt);
+  OptionAdd(&opt,"fast", 'x', &fast);
+ 
+  arg=OptionProcess(1,argc,argv,&opt,NULL);  
+
+  if (sname==NULL) sname=sdname;
+  if (ename==NULL) ename=edname;
+
+  sid=RShellRegister(sname,CONTROL_NAME);
+
+  errlog=TaskIDMake(ename);  
+  OpsLogStart(errlog,progname,argc,argv);  
+
+  SiteSetupHardware();
+
+  if (fast) {
+     cp= 157; /* fastsound */
+     scnsc=60;
+     scnus=0;
+     intsc= fast_intt;
+     intus=0;
+  }
+  if ( discretion) cp= -cp;
+
+  txpl=(rsep*20)/3;
+
+  if (fast) sprintf(progname,"normalsound (fast)");
+  else sprintf(progname,"normalsound");
+
+  OpsFitACFStart();
+  OpsSetupTask(tasklist);
+  for (n=0;n<tnum;n++) {
+    RMsgSndReset(tlist[n]);
+    RMsgSndOpen(tlist[n],strlen(cmdlne),cmdlne);     
+  }
+
+  /* only set frequency to their default on program start */
+  TimeReadClock(&yr,&mo,&dy,&hr,&mt,&sc,&us);
+  if (OpsDayNight()==1) {
+    stfrq=dfrq;
+  } else {
+    stfrq=nfrq;
+  }
+
+  do {
+
+    if (SiteStartScan()==0) continue;
+    if (OpsReOpen(2,0,0) !=0) {
+      ErrLog(errlog,progname,"Opening new files.");
+      for (n=0;n<tnum;n++) {
+        RMsgSndClose(tlist[n]);
+        RMsgSndOpen(tlist[n],strlen(cmdlne),cmdlne);     
+      }
+    }
+
+    scan=1;
+    ErrLog(errlog,progname,"Starting scan.");
+    if (xcnt>0) {
+      cnt++;
+      if (cnt==xcnt) {
+        xcf=1;
+        cnt=0;
+      } else xcf=0;
+    } else xcf=0;
+
+    skip=OpsFindSkip(scnsc,scnus);
+    if (backward) {
+      bmnum=sbm-skip;
+      if (bmnum<ebm) bmnum=sbm;
+    } else {
+      bmnum=sbm+skip;
+      if (bmnum>ebm) bmnum=sbm;
+    }
+
+    do {
+      TimeReadClock(&yr,&mo,&dy,&hr,&mt,&sc,&us);
+      if (OpsDayNight()==1) {
+        mpinc=dmpinc;
+        frang=dfrang;
+      } else {
+        mpinc=nmpinc;
+        frang=nfrang;
+      }
+
+      sprintf(logtxt,"Integrating beam:%d intt:%ds.%dus (%d:%d:%d:%d)",bmnum,
+                      intsc,intus,hr,mt,sc,us);
+      ErrLog(errlog,progname,logtxt);
+      ErrLog(errlog,progname,"Setting beam.");
+      SiteSetIntt(intsc,intus);
+      SiteSetBeam(bmnum);
+
+      ErrLog(errlog,progname,"Doing clear frequency search."); 
+      if (SiteFCLR(stfrq,stfrq+frqrng)==FREQ_LOCAL)
+        ErrLog(errlog,progname,"Frequency Synthesizer in local mode.");
+      SiteSetFreq(tfreq);
+
+      sprintf(logtxt,"Transmitting on: %d (Noise=%g)",tfreq,noise);
+      ErrLog(errlog,progname,logtxt);
+      tsgid=SiteTimeSeq(ptab);
+      nave=SiteIntegrate(lags);  
+      if (nave < 0) { 
+        sprintf( logtxt, "Integration error: %d", nave);
+        ErrLog(errlog,progname, logtxt); 
+        continue;
+      }
+      sprintf(logtxt,"Number of sequences: %d",nave);
+      ErrLog(errlog,progname,logtxt);
+
+      OpsBuildRaw(&prm,&raw,ptab,lags);
+      FitACF(&prm,&raw,&fblk,&fit);
+
+      ErrLog(errlog,progname,"Sending messages."); 
+      msg.num=0;
+      msg.tsize=0;
+      RMsgSndAdd(&msg,sizeof(struct RadarParm),(unsigned char *) &prm, PRM_TYPE,0); 
+      RMsgSndAdd(&msg,sizeof(struct RawData),(unsigned char *) &raw, RAW_TYPE,0);    
+      RMsgSndAdd(&msg,sizeof(struct FitData),(unsigned char *) &fit, FIT_TYPE,0);   
+      RMsgSndAdd(&msg,strlen(progname)+1,progname, NME_TYPE,0);   
+      for (n=0;n<tnum;n++) RMsgSndSend(tlist[n],&msg); 
+  
+      ErrLog(errlog,progname,"Polling for exit."); 
+      exitpoll=RadarShell(sid,&rstable);
+      if (exitpoll !=0) break;
+      scan=0;
+      if (bmnum==ebm) break;
+      if (backward) bmnum--;
+      else bmnum++;
+
+    } while (1);
+    ErrLog(errlog,progname,"Waiting for scan boundary."); 
+  
+    if (exitpoll==0) {
+      /* In here comes the sounder code */
+      /* see if it's time for a new freq search */
+      time(&t_now);
+      do_new_freq_search= ( freq_dwell>0 && freq_dwell<=((t_now-last_freq_search)/60.) );
+      /* set the "sounder mode" scan variable */
+      scan=-2;
+      /* set the xcf variable to do cross-correlations (AOA) */
+      xcf=1;
+      /* we have time until the end of the minute to do sounding */
+      /* minus a safety factor given in time_needed */
+      TimeReadClock(&yr,&mo,&dy,&hr,&mt,&sc,&us);
+      sounder_time= 60.0 - ( sc + us/ 1000000.0);
+      /* we do not implement to no sounding mode here */
+      /* do a new frequency search if it's time */
+      if( do_new_freq_search && sounder_time>=5 ) {
+	    do_new_freq_search=0;
+	    stfrq= find_optimal_freq( stfrq, cutlass, fw, sounder_freqs, sounder_freqs_total, sounder_data, act_snd_rec);
+        sprintf( logtxt,"New Opt Freq; %d\n", stfrq);
+        ErrLog( errlog, progname, logtxt);
+	    last_freq_search= t_now;
+      }
+      sounder_beam_loop= ( sounder_time-(float)sounder_intt > time_needed );
+      while( sounder_beam_loop ) {
+	    intsc= sounder_intt;
+	    /* set the beam */
+	    bmnum=sounder_beams[sounder_beam_count]+odd_beams;
+	    /* sounder_freq will be an array of frequencies to step through */
+	    if( !cutlass )
+	      sounder_freq=sounder_freqs[sounder_freq_count];
+/*
+	else {
+	  sounder_freq=lsfreq[sounder_freqs[sounder_freq_count]];
+	  frqrng=lfreq_range[sounder_freqs[sounder_freq_count]];
+	}
+*/
+	  /* the scanning code here */	
+	  sprintf(logtxt,"Integrating SND beam:%d intt:%ds.%dus (%d:%d:%d:%d)", bmnum, intsc,intus,hr,mt,sc,us);
+	  ErrLog(errlog,progname,logtxt);
+	  ErrLog(errlog,progname,"Setting SND beam.");
+	  SiteSetIntt(intsc,intus);
+	  SiteSetBeam(bmnum);
+	  ErrLog( errlog, progname, "Doing SND clear frequency search."); 
+	  if (SiteFCLR( sounder_freq, sounder_freq + frqrng)==FREQ_LOCAL)
+        ErrLog(errlog,progname,"Frequency Synthesizer in local mode.");
+	  SiteSetFreq(tfreq);
+/*
+	  sprintf(logtxt,"Transmitting SND on: %d (Noise=%g)",tfreq,noise);
+	  ErrLog( errlog, progname, logtxt);
+*/
+	  tsgid= SiteTimeSeq(ptab);
+	  nave= SiteIntegrate( lags);   
+	  if (nave < 0) {
+            sprintf( logtxt, "SND integration error: %d", nave);
+	    ErrLog(errlog,progname, logtxt); 
+            continue;
+	  }
+	  sprintf(logtxt,"Number of SND sequences: %d",nave);
+	  ErrLog(errlog,progname,logtxt);
+
+	  OpsBuildRaw(&prm,&raw,ptab,lags);
+	  FitACF(&prm,&raw,&fblk,&fit);
+
+	  ErrLog( errlog, progname, "Sending SND messages."); 
+	  msg.num= 0;
+	  msg.tsize= 0;
+	  RMsgSndAdd( &msg, sizeof(struct RadarParm), (unsigned char *) &prm, PRM_TYPE, 0); 
+	  RMsgSndAdd( &msg, sizeof(struct RawData), (unsigned char *) &raw, RAW_TYPE, 0);    
+	  RMsgSndAdd( &msg, sizeof(struct FitData), (unsigned char *) &fit, FIT_TYPE, 0);   
+	  RMsgSndAdd( &msg, strlen(progname)+1, progname, NME_TYPE, 0);
+	  /* Only send these to echo_data; otherwise they get written to the data files */   
+	  RMsgSndSend( tlist[ 0], &msg);
+
+	  sprintf( logtxt, "SBC: %d  SFC: %d\n", sounder_beam_count, sounder_freq_count);
+	  ErrLog( errlog, progname, logtxt);
+	  /* save the sounding mode data */
+	  write_sounding_record_new( progname, &prm, &fit, sounder_data, &act_snd_rec);
+ 
+	  ErrLog( errlog, progname, "Polling SND for exit."); 
+	  exitpoll=RadarShell(sid,&rstable);
+	  if (exitpoll !=0) break;
+
+	  /* check for the end of a beam loop */
+      sounder_freq_count++;
+	  if( sounder_freq_count >= sounder_freqs_total ) {
+	    /* reset the freq counter and increment the beam counter */
+	    sounder_freq_count=0;
+	    sounder_beam_count++;
+	    if( sounder_beam_count>=sounder_beams_total ) {
+	      sounder_beam_count=0;
+	      if( odd_beams==0 )
+	        odd_beams=1;
+	      else
+	        odd_beams=0;
+	      sounder_freq_count=0;
+	    }
+	  }
+	  /* see if we have enough time for another go round */ 
+	  TimeReadClock( &yr, &mo, &dy, &hr, &mt, &sc, &us);
+	  sounder_time= 60.0 - ( sc + us/ 1000000.0);
+	  sounder_beam_loop= ( sounder_time-(float)sounder_intt > time_needed );
+      }
+      /* now wait for the next normal_scan */
+      intsc=normal_intt;
+      if ( fast) intsc= fast_intt;
+      OpsWaitBoundary(scnsc,scnus);
+    }
+
+  } while (exitpoll==0);
+  SiteEnd();
+  for (n=0;n<tnum;n++) RMsgSndClose(tlist[n]);
+  ErrLog(errlog,progname,"Ending program.");
+  RShellTerminate(sid);
+  return 0;   
+} 
+ 
+/********************** function write_sounding_record() ************************/
+void write_sounding_record( char *progname, struct RadarParm *prm, struct FitData *fit, struct sounder_struct *sounder_data, int *act_snd_rec)
+{
+  int i;
+
+  struct header_struct
+	{
+	double stime;
+	unsigned char site_id;
+	unsigned char beam_no;
+	unsigned short freq;
+	unsigned short noise;
+	unsigned short frange;
+	unsigned short rsep;
+	unsigned char gsct[10];
+	unsigned char qflg[10];
+	char program_name[40];
+	short unused1;
+	short unused2;
+	short unused3;
+	} header;
+
+  struct data_struct
+	{
+	short vel;
+	unsigned short width;
+	unsigned short AOA;
+	short unused1;
+	short unused2;
+	unsigned char unused3;
+	unsigned char pwr;
+	} data;
+
+  //char data_path[]={"/data/snd/"}, data_filename[50], filename[80];
+  char data_path[100], data_filename[50], filename[80];
+
+  int byte, good_ranges[75];
+
+  double min_vel=-3000, max_vel=3000;
+  double max_width=1000;
+  double min_power=0, max_power=50;
+  double min_AOA=0, max_AOA=90.;
+
+  char *snd_dir;
+  FILE *out;
+
+  struct sounder_struct *act_snd_data;
+
+
+  /* set up the data directory */
+  /* get the snd data dir */
+  snd_dir= getenv("SD_SND_PATH");
+  if( snd_dir==NULL )
+    sprintf( data_path,"/data/snd/");
+  else
+    memcpy( data_path,snd_dir,strlen(snd_dir));
+//  dpl= strlen( data_path);
+//  if( data_path[ dpl - 1] != '/' ) {
+//    data_path[ dpl]='/';
+//    data_path[ dpl + 1]=0;
+//  } else
+//    data_path[ dpl]=0;
+
+  /* make up the filename */
+  /* YYYYMMDDHH */
+  sprintf( data_filename, "%04d%02d%02d%02d%s", prm->time.yr, prm->time.mo, prm->time.dy, (prm->time.hr/ 2)* 2, getenv("SD_RADARCODE"));
+  /* finally make the filename */
+  sprintf( filename, "%s/%s.snd", data_path, data_filename);
+
+  /* open the output file */
+  out= fopen(filename,"a");
+  if( out==NULL ) {
+	/* crap. might as well go home */
+	return;
+  }
+
+  /* make the header */
+  /* initialize the unused values */
+  //header.unused1=0x0FFE;
+  header.unused1= prm->atten;
+  header.unused2= 0x0FFE;
+  header.unused3= 0x0FFE;
+  data.unused1= 0x0FFE;
+  data.unused2= 0x0FFE;
+  data.unused3= 0xFE;
+
+  header.stime= TimeYMDHMSToEpoch( prm->time.yr, prm->time.mo, prm->time.dy, prm->time.hr, prm->time.mt, prm->time.sc);
+  header.site_id= prm->stid;
+  header.beam_no= prm->bmnum;
+  header.freq= prm->tfreq;
+  header.noise= prm->noise.mean;
+  header.frange= prm->frang;
+  header.rsep= prm->rsep;
+  memcpy( header.program_name, progname, sizeof( header.program_name));
+ /* zero out the gscat and qual bytes */
+  for( i=0; i<10; i++ ) {
+    header.gsct[i]= 0;
+    header.qflg[i]= 0;
+  }
+
+  /* now fill them in */
+  byte= 0;
+  for( i=0; i< SND_NRANG; i++ ) {
+    byte=i/8;
+    if( fit->rng[i].gsct==1 ) header.gsct[byte]+=(0x01<<(i%8));
+    if( fit->rng[i].qflg==1  ) {
+      header.qflg[byte]+= (0x01<<(i%8));
+      good_ranges[i]=1;
+    } else {
+      good_ranges[i]=0;
+    }
+  }
+
+  /* write out the header */
+  fwrite( &header, sizeof( header), 1, out);
+
+  /* scale the fit data into the char/shorts */
+  for( i=0; i< SND_NRANG; i++ ) {
+    /* only do the good ranges */
+    if( good_ranges[i] ) {
+      /* do the power */
+      if( fit->rng[i].p_l < min_power ) data.pwr= 0;
+      else if ( fit->rng[i].p_l > max_power ) data.pwr= 255;
+      else data.pwr= 255* fit->rng[i].p_l/ (max_power - min_power);
+      /* do the AOA */
+      if( fit->elv[i].normal < 0 ) data.AOA= 0;
+      else if( fit->elv[i].normal > 90.0 ) data.AOA= 65535;
+      else data.AOA= 65535* fit->elv[i].normal/ (max_AOA-min_AOA);
+      /* do the velocity */
+      if( fit->rng[i].v < 0 ) {
+        if( fit->rng[i].v < min_vel ) data.vel=-32768;
+        else data.vel= -(32767/ min_vel)* fit->rng[i].v-1;
+      } else {
+        if( fit->rng[i].v > max_vel ) data.vel=32767;
+        else data.vel=(32767/ max_vel)* fit->rng[i].v;
+      }
+      /* do the width */
+      if( fit->rng[i].w_l > max_width ) data.width= 65535;
+      else data.width= ( 65535/ max_width)* fit->rng[i].w_l;
+      /* write out the data structure */
+      fwrite( &data, sizeof( data), 1, out);
+    }
+  }
+  fclose(out);
+
+
+  /* Fill the next sounder data record */
+  act_snd_data= sounder_data + *act_snd_rec;
+  act_snd_data->stime= TimeYMDHMSToEpoch( prm->time.yr, prm->time.mo, prm->time.dy, prm->time.hr, prm->time.mt, prm->time.sc);
+  memcpy( act_snd_data->program_name, progname, sizeof(act_snd_data->program_name));
+  act_snd_data->site_id= prm->stid;
+  act_snd_data->beam_num= prm->bmnum;
+  act_snd_data->freq= prm->tfreq;
+  act_snd_data->noise= prm->noise.mean;
+  act_snd_data->frange= prm->frang;
+  act_snd_data->rsep= prm->rsep;
+  for( i=0; i< SND_NRANG; i++ ) {
+    act_snd_data->pwr[ i]= fit->rng[ i].p_l;
+    act_snd_data->vel[ i]= fit->rng[ i].v;
+    act_snd_data->width[ i]= fit->rng[ i].w_l;
+    act_snd_data->AOA[ i]= fit->elv[ i].normal;
+    act_snd_data->gsct[ i]= fit->rng[ i].gsct;
+    act_snd_data->qflg[ i]= fit->rng[ i].qflg;
+  }
+  *act_snd_rec= *act_snd_rec + 1;
+  if ( *act_snd_rec >= NUM_SND_DATA) *act_snd_rec= 0;
+}
+
+/********************** function write_sounding_record_new() ************************/
+/* changed the data structure */
+
+void write_sounding_record_new( char *progname, struct RadarParm *prm, struct FitData *fit, struct sounder_struct *sounder_data, int *act_snd_rec)
+{
+  int i;
+
+  struct header_struct
+	{
+	long int stime;
+	short int  site_id;
+	short int beam_no;
+	short int freq;
+	short int noise;
+	short int frange;
+	short int rsep;
+	short int gsct[ SND_NRANG];
+	short int qflg[ SND_NRANG];
+	char program_name[40];
+	} header;
+
+  struct data_struct
+	{
+	short int pwr;
+	short int vel;
+	short int width;
+	short int AOA;
+	} data;
+
+  //char data_path[]={"/data/snd/"}, data_filename[50], filename[80];
+  char data_path[100], data_filename[50], filename[80];
+ 
+
+  int  good_ranges[ SND_NRANG];
+
+  char *snd_dir;
+  FILE *out;
+
+  struct sounder_struct *act_snd_data;
+
+
+  /* set up the data directory */
+  /* get the snd data dir */
+  snd_dir= getenv("SD_SND_PATH");
+  if( snd_dir==NULL )
+    sprintf( data_path,"/data/snd/");
+  else {
+    memcpy( data_path,snd_dir,strlen(snd_dir));
+    data_path[ strlen( snd_dir)]= '/';
+    data_path[ strlen( snd_dir) + 1]= 0;
+  }
+
+  /* make up the filename */
+  /* YYYYMMDDHH */
+  sprintf( data_filename, "%04d%02d%02d%02d%s", prm->time.yr, prm->time.mo, prm->time.dy, (prm->time.hr/ 2)* 2, getenv("SD_RADARCODE"));
+  /* finally make the filename */
+  sprintf( filename, "%s%s.snd", data_path, data_filename);
+  /* open the output file */
+  out= fopen(filename,"a");
+  if( out==NULL ) {
+	/* crap. might as well go home */
+	return;
+  }
+
+  /* make the header */
+
+  header.stime= TimeYMDHMSToEpoch( prm->time.yr, prm->time.mo, prm->time.dy, prm->time.hr, prm->time.mt, prm->time.sc);
+  header.site_id= prm->stid;
+  header.beam_no= prm->bmnum;
+  header.freq= prm->tfreq;
+  header.noise= prm->noise.mean;
+  header.frange= prm->frang;
+  header.rsep= prm->rsep;
+  memcpy( header.program_name, progname, sizeof( header.program_name));
+ /* zero out the gscat and qual bytes */
+  for( i=0; i< SND_NRANG; i++ ) {
+    header.gsct[i]= fit->rng[i].gsct;
+    header.qflg[i]= fit->rng[i].qflg;
+    good_ranges[ i]= ( fit->rng[i].qflg == 1);
+  }
+
+  /* write out the header */
+  fwrite( &header, sizeof( header), 1, out);
+
+  /* scale the fit data into the char/shorts */
+  for( i=0; i< SND_NRANG; i++ ) {
+    /* only do the good ranges */
+    if( good_ranges[i] ) {
+      /* do the power */
+      data.pwr= fit->rng[i].p_l;
+      /* do the velocity */
+      data.vel= fit->rng[i].v;
+      /* do the AOA */
+      data.AOA= fit->elv[i].normal;
+      /* do the width */
+      data.width= fit->rng[i].w_l;
+      /* write out the data structure */
+      fwrite( &data, sizeof( data), 1, out);
+    }
+  }
+  fclose(out);
+
+
+  /* Fill the next sounder data record */
+  act_snd_data= sounder_data + *act_snd_rec;
+  act_snd_data->stime= TimeYMDHMSToEpoch( prm->time.yr, prm->time.mo, prm->time.dy, prm->time.hr, prm->time.mt, prm->time.sc);
+  memcpy( act_snd_data->program_name, progname, sizeof(act_snd_data->program_name));
+  act_snd_data->site_id= prm->stid;
+  act_snd_data->beam_num= prm->bmnum;
+  act_snd_data->freq= prm->tfreq;
+  act_snd_data->noise= prm->noise.mean;
+  act_snd_data->frange= prm->frang;
+  act_snd_data->rsep= prm->rsep;
+  for( i=0; i< SND_NRANG; i++ ) {
+    act_snd_data->pwr[ i]= fit->rng[ i].p_l;
+    act_snd_data->vel[ i]= fit->rng[ i].v;
+    act_snd_data->width[ i]= fit->rng[ i].w_l;
+    act_snd_data->AOA[ i]= fit->elv[ i].normal;
+    act_snd_data->gsct[ i]= fit->rng[ i].gsct;
+    act_snd_data->qflg[ i]= fit->rng[ i].qflg;
+  }
+  *act_snd_rec= *act_snd_rec + 1;
+  if ( *act_snd_rec >= NUM_SND_DATA) *act_snd_rec= 0;
+}
+
+/****************** function compute_scatter_percentage *************************/
+/* Mod: 20050315																*/
+/* Use ths last ~15min sounder data to calculate the ionospheric scatter percentage */
+/* for each sounder frequency and in each beam									*/
+/* a lot more could be done, but for now we will keep it simple					*/
+
+void compute_scatter_percentage( struct sounder_struct *sounder_data, int act_snd_rec, int sounder_freqs[], int sft, float iscat_percent[ MAX_SND_FREQS][ SND_NBM] )
+{
+  struct sounder_struct *act_snd_data;
+  int isnd, jsnd, ifrq, i;
+  int returns=0, gscat_returns=0;
+  
+  for ( jsnd=0; jsnd< NUM_SND_DATA/ 4; jsnd++) {
+    isnd= act_snd_rec - jsnd;
+    if (isnd < 0) isnd= isnd + NUM_SND_DATA;
+    act_snd_data= sounder_data + isnd;
+    /* make sure this record has data */
+    if (act_snd_data->stime > 0 ) {
+      returns=0;
+      gscat_returns=0;
+      for( i=0; i< SND_NRANG; i++ ) {
+	if( ( act_snd_data->qflg[i] == 1) && act_snd_data->pwr[i] >= 3.0 && act_snd_data->width[i] < 500.0 ) {
+	  returns++;
+	  if( act_snd_data->gsct[i] ) gscat_returns++;
+	}
+      }
+     for ( ifrq=0; ifrq< sft; ifrq++) {
+       if ( (act_snd_data->freq >= sounder_freqs[ ifrq]) && (act_snd_data->freq <= sounder_freqs[ ifrq] + frqrng) )
+         break;
+     }
+     iscat_percent[ ifrq][act_snd_data->beam_num]= 100.0* (float)(returns - gscat_returns)/ SND_NRANG;
+    }
+  }
+}
+
+/****************** function average_scatter_percentage *************************/
+/* what is fw good for ?? */
+
+void average_scatter_percentages( float iscat_percent[ MAX_SND_FREQS][ SND_NBM], int sft, float average_iscat_percent[ MAX_SND_FREQS], int fw )
+{
+int ifrq, ibm;
+
+  /* average the scatter percentages over all beams */
+  for( ifrq=0; ifrq < sft; ifrq++ ) {
+    average_iscat_percent[ifrq]= 0.0;
+    for( ibm=0; ibm < SND_NBM; ibm++ )
+      average_iscat_percent[ ifrq]+= iscat_percent[ ifrq][ ibm];
+    average_iscat_percent[ ifrq]/= 16.0;
+    if( fw ) average_iscat_percent[ ifrq]*= ifrq;
+  }
+}
+
+/******************* function find_optimal_freq_local() ************************/
+/* our frequency optimization scheme is this:                          */
+/*                                                                     */
+/* at each frequency, find the most recent set of range data for each  */
+/* beam. filter this data and then find the percentage of data points  */
+/* that were ionospheric backscatter. to get the optimal frequency,    */
+/* average over all beams at each frequency and look for the freq      */
+/* with the highest percentage of ionsopheric backscatter.             */
+
+int find_optimal_freq(int start_freq, int cutlass, int fw, int sounder_freqs[], int sft, struct sounder_struct *sounder_data, int act_snd_rec)
+{
+  int i,j;
+  int def_freq, def_freq_bin;
+  /* array of iono scatter percentages (freq and beam number) */
+  float iscat_percent[ MAX_SND_FREQS][ SND_NBM];
+  float average_iscat_percent[ MAX_SND_FREQS];
+  float max_scatter=-10;
+  int max_freq_bin=0;
+  int dlf;
+  FILE *out;
+ 
+
+  /* set the optimal freq to the sounder frequency closest to start_freq in case we don't find a good one; 20060308 DAndre */
+  if( !cutlass ) {
+    dlf= 100000;
+    for ( i= 0; i < sft; i++) { 
+      if ( fabs( start_freq - sounder_freqs[ i]) < dlf) {
+        dlf= fabs( start_freq - sounder_freqs[ i]);
+        def_freq_bin= i;
+      }
+    }
+  }
+/*
+  else
+    def_freq_bin=lsfreq[def_freq]/1000;
+*/
+
+  /* initialize the arrays */
+  for( i=0; i<MAX_SND_FREQS; i++ )
+    for( j=0; j<SND_NBM; j++ ) {
+      iscat_percent[i][j]=0;
+    }
+
+  compute_scatter_percentage( sounder_data, act_snd_rec, sounder_freqs, sft, iscat_percent);
+  average_scatter_percentages( iscat_percent, sft, average_iscat_percent, fw );
+  max_scatter=-10;
+  for( i=0; i< sft; i++ )
+    if( average_iscat_percent[i] >= max_scatter ) {
+      max_scatter= average_iscat_percent[ i];
+      max_freq_bin=i;
+    }
+
+  /* set a threshold on the improvement */
+  if( max_scatter < 1.15* average_iscat_percent[def_freq_bin] || ( max_scatter - average_iscat_percent[def_freq_bin]) < 0.75 )
+    max_freq_bin=def_freq_bin;
+
+  def_freq= sounder_freqs[ max_freq_bin];
+
+  out=fopen("/tmp/freq_search.out","w");
+  if( out != NULL ) {
+    for( i= 0; i < sft; i++ ) {
+      if( !fw ) 
+	fprintf(out,"\n%2d %d %10.7lf", i, sounder_freqs[ i], average_iscat_percent[i]); 
+      else
+	fprintf(out,"\n%2d %d %10.7lf", i, sounder_freqs[ i], average_iscat_percent[i]/ i); 
+    }
+    fprintf( out, "\nCutlass: %d",cutlass);
+    fprintf( out, "\nFreq Weighting: %d",fw);
+    fprintf( out, "\nReturned Frequency: %d kHz",def_freq);
+    fprintf( out, "\n");
+    fclose(out);
+  }
+
+  return(def_freq);
+}
+
+
+
+
+
+

--- a/qnx4/sd_leicester/pyk/normalsound.2.05/version.info
+++ b/qnx4/sd_leicester/pyk/normalsound.2.05/version.info
@@ -1,0 +1,19 @@
+#$Log: version.info,v $
+#Revision 2.5  2006/07/12 15:50:45  code
+#Added call to set up command line and limited data written to rawacf and fitacf.
+#
+#Revision 2.4  2006/04/13 18:14:56  barnes
+#Incorporated Dieter Andre's bug fix.
+#
+#Revision 2.3  2006/02/07 20:56:24  barnes
+#Simon Shepherd's modification to the lag table.
+#
+#Revision 2.2  2006/02/07 17:51:13  barnes
+#Added Dieter Andre's improved error logging.
+#
+#Revision 2.1  2005/07/19 18:45:06  barnes
+#First revision included in the ROS 1.08.
+#
+#
+normalsound.c 2.05
+

--- a/qnx4/sd_leicester/pyk/stereoscan.1.04/makefile
+++ b/qnx4/sd_leicester/pyk/stereoscan.1.04/makefile
@@ -1,0 +1,55 @@
+# Makefile for stereoscan
+# =======================
+# by R.J.Barnes
+#
+#
+
+
+INCLUDE=-I$(IPATH)/base -I$(IPATH)/general -I$(IPATH)/superdarn \
+	-I$(IPATH)/radarqnx4 \
+	-I$(USR_IPATH)/radarqnx4/ops \
+	-I$(USR_IPATH)/radarqnx4/site.$(SD_RADARCODE)
+
+OBJS = stereoscan.o
+SRC=stereoscan.c
+IGNVER=1
+OUTPUT = $(USR_BINPATH)/stereoscan
+SUDO = 1 
+LIBS=-lsite.${SD_RADARCODE}.1 -lops.1 -lfitacf.1 -lradar.1 -lerrlog.1 \
+     -lrs.1 -lfreq.1 -lacf.1 -ltcpipmsg.1 -lrawfeed.1 -ltsg.1  \
+     -ltaskid.1 -lrmsgsnd.1 -lrtimer.1 -lrtime.1 -lrmath.1 -lopt.1 
+
+include $(SITELIB).${SD_RADARCODE}
+
+ifdef STEREO
+include $(MAKEBIN)
+else
+version: version.info $(SRC)
+	$(BINPATH)/rcsv -t version.info
+clean:
+	rm -f *.o
+	rm -f $(OUTPUT)
+endif
+
+
+
+
+
+
+
+  
+
+
+
+
+
+
+
+
+
+  
+
+
+ 
+
+

--- a/qnx4/sd_leicester/pyk/stereoscan.1.04/stereoscan.c
+++ b/qnx4/sd_leicester/pyk/stereoscan.1.04/stereoscan.c
@@ -1,0 +1,1371 @@
+/* modfied to add correct cts x functionality for Blackstone JDT 30 Jne 2008 */
+/* modifed for Blackstone by JDT 29 Feb 2008 */
+
+/* stereoscan.c
+   ============
+   Author: R.J.Barnes
+*/
+
+/*
+ Copyright 2004 The Johns Hopkins University/Applied Physics Laboratory.
+ All rights reserved.
+ 
+ This material may be used, modified, or reproduced by or for the U.S.
+ Government pursuant to the license rights granted under the clauses at DFARS
+ 252.227-7013/7014.
+ 
+ For any other permissions, please contact the Space Department
+ Program Office at JHU/APL.
+ 
+ This Distribution and Disclaimer Statement must be included in all copies of
+ "Radar Operating System - Control Programs" (hereinafter "the Program").
+ 
+ The Program was developed at The Johns Hopkins University/Applied Physics
+ Laboratory (JHU/APL) which is the author thereof under the "work made for
+ hire" provisions of the copyright law.  
+ 
+ JHU/APL assumes no obligation to provide support of any kind with regard to
+ the Program.  This includes no obligation to provide assistance in using the
+ Program or to provide updated versions of the Program.
+ 
+ THE PROGRAM AND ITS DOCUMENTATION ARE PROVIDED AS IS AND WITHOUT ANY EXPRESS
+ OR IMPLIED WARRANTIES WHATSOEVER.  ALL WARRANTIES INCLUDING, BUT NOT LIMITED
+ TO, PERFORMANCE, MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE ARE
+ HEREBY DISCLAIMED.  YOU ASSUME THE ENTIRE RISK AND LIABILITY OF USING THE
+ PROGRAM TO INCLUDE USE IN COMPLIANCE WITH ANY THIRD PARTY RIGHTS.  YOU ARE
+ ADVISED TO TEST THE PROGRAM THOROUGHLY BEFORE RELYING ON IT.  IN NO EVENT
+ SHALL JHU/APL BE LIABLE FOR ANY DAMAGES WHATSOEVER, INCLUDING, WITHOUT
+ LIMITATION, ANY LOST PROFITS, LOST SAVINGS OR OTHER INCIDENTAL OR
+ CONSEQUENTIAL DAMAGES, ARISING OUT OF THE USE OR INABILITY TO USE THE
+ PROGRAM."
+ 
+ 
+ 
+ 
+ 
+  
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/types.h>
+#include <sys/proxy.h>
+#include <sys/kernel.h>
+#include <string.h>
+#include <time.h>
+#include "rtypes.h"
+#include "option.h"
+#include "rtime.h"
+#include "limit.h"
+#include "radar.h"
+#include "rprm.h"
+#include "rawdata.h"
+#include "fitblk.h"
+#include "fitdata.h"
+#include "fitacf.h"
+
+#include "taskid.h"
+#include "errlog.h"
+#include "freq.h"
+#include "rmsg.h"
+#include "radarshell.h"
+#include "rmsgsnd.h"
+#include "tsg.h"
+#include "tsgtable.h"
+#include "maketsg.h"
+#include "global.h"
+#include "globals.h"
+#include "setup.h"
+#include "reopen.h"
+#include "tmseq.h"
+#include "raws.h"
+#include "sync.h"
+#include "interface.h"
+#include "hdw.h"
+
+/*
+ $Log: stereoscan.c,v $
+ Revision 1.4  2007/08/09 14:09:51  code
+ Allowed command lines to be passed as a file.
+
+ Revision 1.3  2007/08/08 16:55:44  code
+ Fixed bug in using hex notation for stid.
+
+ Revision 1.2  2006/07/12 15:51:43  code
+ Added call to set up command line and limited data written to rawacf and fitacf.
+
+ Revision 1.1  2006/03/30 11:19:18  barnes
+ Initial revision
+ 
+*/
+
+/*
+	Modified 10/12/2001 PH
+
+	Added bnA and bnB frequency band options to cycle through frequency
+	bands during each scan. No check is made for invalid band numbers.
+	A band number of -1 is ignored. Bands can be added/removed at any
+	time using radar_shell, changes won't take effect until the end of
+	the current scan. If no band numbers are specified, normal day/night
+	frequencies are used.
+
+	Frequency bands can also be specified for campA and campB modes.
+
+	Extra options can be placed in a separate schedule file. The file
+	name should be the last argument in the schedule argument list and
+	should include the full path.
+
+	Modified 16/01/02 PH
+
+	Fixed synchronisation bug. The code wasn't subtracting the time taken
+	for a clear frequency search from the beam integration time, resulting
+	in an extended beam dwell time and a sweep lasting for more than 60 s
+	for fast stereo and 120 s for slow stereo 7 s integration.
+
+	Standard slow stereo (normal stereo) is now 7 seconds (by Mark Lester).
+
+	Modified 30/01/02 PH
+
+	added -cts? options that pre-set other options
+
+			dwell	chan A	cpidA	chan B	cpidB	Ice/Fin/BKS	 offset	range
+			------	------	------	------	------	-----------  ------	-----
+	cts2 -    7		normal	 152	 tbj	-26002	 5 / 9 / 7	 +400	 45
+	cts4 -	  7		normal	 152	normal	-26004	 5 / 9 / 7	 +400	 45
+	cts6 -	  7		normal	 152	1 camp	-26006	 5 / 9 / 7	 +400	 45
+	cts8 -	  7		normal	 152	2 camp	-26008	 5 / 9 / 7	 +400	 45
+
+	cts3 -	  3		normal	 153	 tbj	-26003	 5 / 9 / 7	 +400	 45
+	cts5 -	  3		normal	 153	normal	-26005	 5 / 9 / 7	 +400	 45
+	cts7 -	  3		normal	 153	1 camp	-26007	 5 / 9 / 7	 +400	 45
+	cts9 -	  3		normal	 153	2 camp	-26009	 5 / 9 / 7	 +400	 45
+
+	Single camp beams are hard coded to the standard Finland beam 9,
+	Iceland beam 5 and Blackstone 7
+
+	Double camp beams are the same for both radars and defined as
+	DOUBLE_CAMP_LOW and DOUBLE_CAMP_HIGH.
+
+	range gates and first range are let to the default settings of 45km
+	and 180km respectively.
+
+	specifying any cts option will override low and high beam, offset, cpIDs,
+	integration time and scan boundary. tbj mode overrides frequencies.
+
+	Modified 05/04/02 PH
+
+	Uses the new stereo aware version of fitacf (1.06).
+
+	Modified 30/04/2002 PH
+
+	Added cpidA and cpidB to set the cpid. This option overrides any
+	previously defined cpid.
+
+	Added bmnA and bmnB to cycle through beams numbers on both channels.
+	To specify double camp beams use -bm0B 5 -bm1B 9
+	To specify single camp beams use -bm0B 5
+	The same beam number can be specified more than once.
+	The number of beams in the channel A beam list determines the number of
+	beams per scan. This is important if you are also using frequency lists.
+
+	cts 2, 3, 4, 5 beams patterns can be changed with bm*A and bm*B options.
+
+	Modified 25/09/02 PH
+
+	Changed so that the B channel frequency band changes at the end of the
+	channel B scan, so that it is independent of the number of beams on
+	channel A.
+
+  Modified 7th Dec 2001 to add camp beam flags
+  Modified 23 Nov 2001 to add new -ns and -fs flags and changed some defaults
+  Modified 10th Aug to account for backwards scanning radars
+  Modified 8th Aug fitacf_s
+  Julian modified version. March 2001
+
+*/
+
+#define CPID_A -6401
+#define CPID_B -26401
+#define CPID_NS 152
+#define CPID_FS 153
+
+
+#define INTT      7
+#define RSEP_A 45
+#define RSEP_B 45
+#define FRANG_A 180
+#define FRANG_B 180
+
+
+#define LOW_BEAM_A   0
+#define HIGH_BEAM_A  15
+#define LOW_BEAM_B   0
+#define HIGH_BEAM_B  15
+
+#define SINGLE_CAMP_BEAM_PYK 5
+#define SINGLE_CAMP_BEAM_HAN 9
+#define SINGLE_CAMP_BEAM_BKS 7
+
+
+#define DOUBLE_CAMP_LOW 5
+#define DOUBLE_CAMP_HIGH 9
+
+
+#define UCONT_NAME "ucont_moni"
+
+#define CHN_A 0
+#define CHN_B 1
+
+#define NUMBANDS 10
+#define NUMBEAMS 16
+
+
+#define SCHEDULER "schedule"
+#define ERRLOG "errlog"
+
+#define CONTROL_NAME "control_program"
+#define TASK_NAMES "echo_data","rawacfwrite","fitacfwrite"
+
+
+
+void u_read_uconts(void);
+void u_init_freq_bands(void);
+
+void RemInvalidEntries(int ifreqsA[], int ifreqsB[]);
+void FindNumBands(int *numfreqbandsA, int *numfreqbandsB, int *day_nightA, int *day_nightB, int ifreqsA[], int ifreqsB[], int print);
+void RemInvalidBeams(int ibeamsA[], int ibeamsB[]);
+void FindNumBeams(int *numbeamsA, int *numbeamsB, int ibeamsA[], int ibeamsB[], int print);
+
+char cmdlne[1024];
+char progid[80]={"$Id: stereoscan.c,v 1.4 2007/08/09 14:09:51 code Exp $"};
+char progname[256];
+struct TaskID *errlog;
+
+int usfreq[100];
+int ufreq_range[100];
+
+pid_t uucont_proxy;
+
+int low_beam_A=LOW_BEAM_A;
+int high_beam_A=HIGH_BEAM_A;
+int low_beam_B=LOW_BEAM_B;
+int high_beam_B=HIGH_BEAM_B;
+
+
+
+
+char *tasklist[]=
+ { TASK_NAMES,
+  0};
+
+int arg=0;
+struct OptionData opt;
+struct OptionFile *optf=NULL;
+      
+int main(int argc,char *argv[]) {
+
+  int ptab[7] = {0,9,12,20,22,26,27};
+
+  int lags[LAG_SIZE][2] = {
+    { 0, 0},		/*  0 */
+    {26,27},		/*  1 */
+    {20,22},		/*  2 */
+    {9,12},		/*  3 */
+    {22,26},		/*  4 */
+    {22,27},		/*  5 */
+
+    {20,26},		/*  7 */
+    {20,27},		/*  8 */
+    {0,9},		/*  9 */
+    {12,22},		/* 10 */
+    {9,20},		/* 11 */
+    {0,12},	  	    /* 12 */
+    {9,22},		/* 13 */
+    {12,26},		/* 14 */
+    {12,27},		/* 15 */
+    {9,26},		/* 16 */
+    {9,27},		/* 17 */
+    {27,27}};		/* alternate lag-0  */
+
+
+  char *sname=NULL;
+  char *ename=NULL;
+  char *sdname={SCHEDULER};
+  char *edname={ERRLOG};
+  char logtxt[1024];
+
+  char a[10];
+
+  int n,i;
+  pid_t sid;
+  int exitpoll=0;
+ 
+  int scnsc=0;
+  int scnus=0;
+ 
+  unsigned char ns=0;
+  unsigned char fs=0;
+
+  int stereo_offset=400; /* channel A delayed by this 
+                            number of microseconds */
+
+
+  int ifreqsA[NUMBANDS],ifreqsB[NUMBANDS];
+
+  int ibeamsA[NUMBEAMS],ibeamsB[NUMBEAMS];
+
+  int day_nightA=1;
+  int day_nightB=1;
+
+  int numfreqbandsA;
+  int numfreqbandsB;
+  
+  int ifreqsA_index=0; 
+  int ifreqsB_index=0;
+  
+  int ifreqsAband;
+  int ifreqsBband;
+
+  int numbeamsA,numbeamsB;
+
+  int ibeamsA_index=0;
+  int ibeamsB_index=0;
+
+  unsigned char cts2=0,cts4=0,cts6=0,cts8=0;
+  unsigned char cts3=0,cts5=0,cts7=0,cts9=0;
+  
+  int cpidA=0,cpidB=0;
+
+  for (i=0;i<NUMBANDS;i++) ifreqsA[i]=ifreqsB[i]=-1;
+  for (i=0;i<NUMBEAMS;i++) ibeamsA[i]=ibeamsB[i]=-1;
+  
+  xcfA=xcfB=1;
+ 
+  cpA=CPID_A;
+  cpB=CPID_B;
+
+  SiteStart();
+ 
+  intsc=INTT;
+  intus=0;
+ 
+  maxattenA=maxattenB=7;
+
+  if ((uucont_proxy=SiteInitProxy(UCONT_NAME))==-1) {
+    perror("cannot attach proxy");
+  }
+ 
+  u_init_freq_bands();
+  
+  strcpy(cmdlne,argv[0]);
+  for (n=1;n<argc;n++) {
+    strcat(cmdlne," ");
+    strcat(cmdlne,argv[n]);
+  } 
+
+  strncpy(combf,progid,80);   
+  OpsSetupCommand(argc,argv);
+  OpsSetupRadar();
+  OpsSetupShell();
+
+  RadarShellAdd(&rstable,"intt",var_LONG,&intsc);
+  RadarShellAdd(&rstable,"inttsc",var_LONG,&intsc);
+  RadarShellAdd(&rstable,"inttus",var_LONG,&intus);
+
+  RadarShellAdd(&rstable,"txplA",var_LONG,&txplA);
+  RadarShellAdd(&rstable,"mpincA",var_LONG,&mpincA);
+  RadarShellAdd(&rstable,"mppulA",var_LONG,&mppulA);
+  RadarShellAdd(&rstable,"mplgsA",var_LONG,&mplgsA);
+  RadarShellAdd(&rstable,"nrangA",var_LONG,&nrangA);
+  RadarShellAdd(&rstable,"frangA",var_LONG,&frangA);
+  RadarShellAdd(&rstable,"rsepA",var_LONG,&rsepA);
+  RadarShellAdd(&rstable,"bmnumA",var_LONG,&bmnumA);
+  RadarShellAdd(&rstable,"xcfA",var_LONG,&xcfA);
+  RadarShellAdd(&rstable,"tfreqA",var_LONG,&tfreqA);
+  RadarShellAdd(&rstable,"scanA",var_LONG,&scanA);
+  RadarShellAdd(&rstable,"mxpwrA",var_LONG,&mxpwrA);
+  RadarShellAdd(&rstable,"lvmaxA",var_LONG,&lvmaxA);
+  RadarShellAdd(&rstable,"rxriseA",var_LONG,&rxriseA);
+  RadarShellAdd(&rstable,"combfA",var_STRING,combfA);
+  RadarShellAdd(&rstable,"cpA",var_LONG,&cpA);
+
+  RadarShellAdd(&rstable,"txplB",var_LONG,&txplB);
+  RadarShellAdd(&rstable,"mpincB",var_LONG,&mpincB);
+  RadarShellAdd(&rstable,"mppulB",var_LONG,&mppulB);
+  RadarShellAdd(&rstable,"mplgsB",var_LONG,&mplgsB);
+  RadarShellAdd(&rstable,"nrangB",var_LONG,&nrangB);
+  RadarShellAdd(&rstable,"frangB",var_LONG,&frangB);
+  RadarShellAdd(&rstable,"rsepB",var_LONG,&rsepB);
+  RadarShellAdd(&rstable,"bmnumB",var_LONG,&bmnumB);
+  RadarShellAdd(&rstable,"xcfB",var_LONG,&xcfB);
+  RadarShellAdd(&rstable,"tfreqB",var_LONG,&tfreqB);
+  RadarShellAdd(&rstable,"scanB",var_LONG,&scanB);
+  RadarShellAdd(&rstable,"mxpwrB",var_LONG,&mxpwrB);
+  RadarShellAdd(&rstable,"lvmaxB",var_LONG,&lvmaxB);
+  RadarShellAdd(&rstable,"rxriseB",var_LONG,&rxriseB);
+  RadarShellAdd(&rstable,"combfB",var_STRING,combfB);
+  RadarShellAdd(&rstable,"cpB",var_LONG,&cpB);
+
+  OptionAdd(&opt, "ns",	'x', &ns);
+  OptionAdd(&opt, "fs",	'x', &fs);
+  OptionAdd(&opt, "e",	't', &ename);  
+  OptionAdd(&opt, "sc",	't', &sname);
+  OptionAdd(&opt, "intt",	'i', &intsc);
+  OptionAdd(&opt, "dfA",	'i', &dfrqA);
+  OptionAdd(&opt, "dfB",	'i', &dfrqB);
+  OptionAdd(&opt, "nfA",	'i', &nfrqA);
+  OptionAdd(&opt, "nfB",	'i', &nfrqB);
+  
+  OptionAdd(&opt, "offset",	'i',&stereo_offset);
+
+  OptionAdd(&opt, "frA",	'i', &frangA);
+  OptionAdd(&opt, "frB",	'i', &frangB);
+  OptionAdd(&opt, "rgA",	'i', &rsepA);
+  OptionAdd(&opt, "rgB",	'i', &rsepB);
+  OptionAdd(&opt, "lbA",	'i', &low_beam_A);
+  OptionAdd(&opt, "hbA",	'i', &high_beam_A);
+  OptionAdd(&opt, "lbB",	'i', &low_beam_B);
+  OptionAdd(&opt, "hbB",	'i', &high_beam_B);
+  OptionAdd(&opt, "sp",	'i', &scnsc);
+
+  OptionAdd(&opt, "cpidA", 'i', &cpidA);
+  OptionAdd(&opt, "cpidB", 'i', &cpidB);
+
+  /* set up remaining shell variables */
+
+  RadarShellAdd(&rstable, "dfA",var_LONG,&dfrqA);
+  RadarShellAdd(&rstable, "dfB",var_LONG,&dfrqB);
+  RadarShellAdd(&rstable, "nfA",var_LONG,&nfrqA);
+  RadarShellAdd(&rstable, "nfB",var_LONG,&nfrqB);
+
+  RadarShellAdd(&rstable, "offset",	var_LONG,&stereo_offset);
+ 
+  RadarShellAdd(&rstable, "low_beamA",	var_LONG,&low_beam_A);
+  RadarShellAdd(&rstable, "high_beamA",var_LONG,&high_beam_A);
+  RadarShellAdd(&rstable, "low_beamB",	var_LONG,&low_beam_B);
+  RadarShellAdd(&rstable, "high_beamB",var_LONG,&high_beam_B);
+  RadarShellAdd(&rstable, "scan_period",var_LONG,&scnsc);
+
+  /* add new options - individual frequency bands */
+
+  strcpy(a,"b0A");
+  for (i = 0; i < NUMBANDS; i++) {
+    a[1] = '0' + i; /* change 2nd char to ACSII number */
+    OptionAdd(&opt, a,	'i', &ifreqsA[i]);
+    RadarShellAdd(&rstable, a, var_LONG, &ifreqsA[i]);
+  }
+
+  strcpy(a,"b0B");
+  for (i = 0; i < NUMBANDS; i++) {
+    a[1] = '0' + i; /* change 2nd char to ACSII number */
+    OptionAdd(&opt, a,	'i', &ifreqsB[i]);
+    RadarShellAdd(&rstable, a, var_LONG, &ifreqsB[i]);
+  }
+
+  strcpy(a,"bm0A");
+  
+  for (i = 0; i < 10; i++) {
+    a[2] = '0' + i;  /* change 3nd char to ACSII number */
+    OptionAdd(&opt, a,	'i', &ibeamsA[i]);
+    RadarShellAdd(&rstable, a, var_LONG, &ibeamsA[i]);
+  }
+
+  strcpy(a,"bm10A");
+  for (i = 0; i < 6; i++) {
+    a[3] = '0' + i;  /* change 4nd char to ACSII number */
+    OptionAdd(&opt, a,	'i', &ibeamsA[i + 10]);
+    RadarShellAdd(&rstable, a, var_LONG, &ibeamsA[i + 10]);
+  }
+
+  strcpy(a,"bm0B");
+  for (i = 0; i < 10; i++) {
+    a[2] = '0' + i;  /* change 3nd char to ACSII number */
+    OptionAdd(&opt, a,	'i', &ibeamsB[i]);
+    RadarShellAdd(&rstable, a, var_LONG, &ibeamsB[i]);
+  }
+
+  strcpy(a,"bm10B");
+  for (i = 0; i < 6; i++) {
+    a[3] = '0' + i; /* change 4nd char to ACSII number */
+    OptionAdd(&opt, a,	'i', &ibeamsB[i + 10]);
+    RadarShellAdd(&rstable, a, var_LONG, &ibeamsB[i + 10]);
+  }
+
+  /* add CTs options */
+
+  OptionAdd(&opt, "cts2", 'x', &cts2);
+  OptionAdd(&opt, "cts3", 'x', &cts3);
+  OptionAdd(&opt, "cts4", 'x', &cts4);
+  OptionAdd(&opt, "cts5", 'x', &cts5);
+  OptionAdd(&opt, "cts6", 'x', &cts6);
+  OptionAdd(&opt, "cts7", 'x', &cts7);
+  OptionAdd(&opt, "cts8", 'x', &cts8);
+  OptionAdd(&opt, "cts9", 'x', &cts9);
+ 
+  arg=OptionProcess(1,argc,argv,&opt,NULL); 
+
+  if (arg<argc) {
+    int farg;
+    FILE *fp=NULL;
+    fp=fopen(argv[arg],"r");
+    if (fp!=NULL) {
+      optf=OptionProcessFile(fp);
+      if (optf !=NULL) {
+        farg=OptionProcess(0,optf->argc,optf->argv,&opt,NULL);
+        OptionFreeFile(optf);
+      }   
+      fclose(fp);
+    }
+  }
+
+  if (sname==NULL) sname=sdname;
+  if (ename==NULL) ename=edname;
+
+  sid=RShellRegister(sname,CONTROL_NAME);
+
+  errlog=TaskIDMake(ename);  
+  OpsLogStart(errlog,progname,argc,argv);  
+
+  /* handle CTs */
+
+  if ((cts2) || (cts4) || (cts6) || (cts8)) {
+    cpA = 152;
+	intsc = 7;
+    intus = 0;
+    stereo_offset = 400;
+    scnsc = 120;
+    scnus = 0;
+
+	/* tbj mode */
+
+    if (cts2) {
+	  cpB = -26002;
+      if (stid==9) {
+	    ifreqsA[0] = 23;
+	    ifreqsB[0] = 23;
+		ifreqsB[1] = 26;
+		ifreqsB[2] = 28;
+		ifreqsB[3] = 30;
+		ifreqsB[4] = 32;
+		ifreqsB[5] = 34;
+		ifreqsB[6] = 35;
+      } else if (stid==10) {
+	    ifreqsA[0] = 3;
+		ifreqsB[0] = 2;
+		ifreqsB[1] = 4;
+		ifreqsB[2] = 5;
+		ifreqsB[3] = 6;
+		ifreqsB[4] = 7;
+		ifreqsB[5] = 8;
+		ifreqsB[6] = 10;
+      } else if (stid==33) {
+	    ifreqsA[0] = 42;
+		ifreqsB[0] = 50;
+		ifreqsB[1] = 40;
+		ifreqsB[2] = 41;
+		ifreqsB[3] = 42;
+		ifreqsB[4] = 43;
+		ifreqsB[5] = 44;
+		ifreqsB[6] = 45;
+      }
+     }
+
+	 /* normal scan */
+
+	 if (cts4) cpB = -26004;
+	
+	 /* single camp beam */
+
+	if (cts6) {
+	  cpB = -26006;
+      if (stid==9) ibeamsB[0] = SINGLE_CAMP_BEAM_PYK;
+      else if (stid==33) ibeamsB[0] = SINGLE_CAMP_BEAM_BKS;
+      else ibeamsB[0] = SINGLE_CAMP_BEAM_HAN;
+
+	}
+
+	/* double camp beam */
+
+	if (cts8) {
+	  cpB = -26008;
+
+	  ibeamsB[0] = DOUBLE_CAMP_LOW;
+	  ibeamsB[1] = DOUBLE_CAMP_HIGH;
+	}
+  } else if ((cts3) || (cts5) || (cts7) || (cts9)) {
+    cpA = 153;
+	intsc = 3;
+	stereo_offset = 400;
+	scnsc = 60.0;
+    scnus = 0.0;
+
+	/* tbj */
+
+	if (cts3) {
+	  cpB = -26003;
+       
+	  if (stid==9) {
+	    ifreqsA[0] = 23;
+	    ifreqsB[0] = 23;
+		ifreqsB[1] = 26;
+		ifreqsB[2] = 28;
+		ifreqsB[3] = 30;
+		ifreqsB[4] = 32;
+		ifreqsB[5] = 34;
+		ifreqsB[6] = 35;
+      } else if (stid==10) {
+	    ifreqsA[0] = 3;
+		ifreqsB[0] = 2;
+		ifreqsB[1] = 4;
+		ifreqsB[2] = 5;
+		ifreqsB[3] = 6;
+		ifreqsB[4] = 7;
+		ifreqsB[5] = 8;
+		ifreqsB[6] = 10;
+      } else if (stid==33) {
+	    ifreqsA[0] = 42;
+		ifreqsB[0] = 50;
+		ifreqsB[1] = 40;
+		ifreqsB[2] = 41;
+		ifreqsB[3] = 42;
+		ifreqsB[4] = 43;
+		ifreqsB[5] = 44;
+		ifreqsB[6] = 45;
+      }
+	}
+
+	/* normal scan */
+
+	if (cts5) cpB = -26005;
+	
+
+	/* single camp beam */
+
+	if (cts7) {
+	  cpB = -26007;
+      if (stid==9) ibeamsB[0] = SINGLE_CAMP_BEAM_PYK;
+      else if (stid==33) ibeamsB[0] = SINGLE_CAMP_BEAM_BKS;
+      else ibeamsB[0] = SINGLE_CAMP_BEAM_HAN;
+
+	}
+
+	/* double camp beam */
+
+	if (cts9) {
+	  cpB = -26009;
+
+	  ibeamsB[0] = DOUBLE_CAMP_LOW;
+	  ibeamsB[1] = DOUBLE_CAMP_HIGH;
+	}
+  } else
+    /* check for normal scan emulation */
+  if (ns) {
+    frangA		= FRANG_A;
+	rsepA		= RSEP_A;
+	low_beam_A	= LOW_BEAM_A;
+	high_beam_A	= HIGH_BEAM_A;
+
+	intsc = 7;
+    intus = 0;
+	scnsc = 120.0;
+    scnus = 0.0;
+	cpA = CPID_NS;  
+  } else
+    /* check for fast scan emulation */
+  if (fs) {
+    frangA		= FRANG_A;
+	rsepA		= RSEP_A;
+	low_beam_A	= LOW_BEAM_A;
+	high_beam_A	= HIGH_BEAM_A;
+
+	intsc = 3;
+    intus = 0;
+	scnsc = 60.0;
+    scnus = 0.0;
+	cpA = CPID_FS;
+  }
+
+  /* set cpid for channel A */
+
+  if (cpidA) {
+     cpA = cpidA;
+	 cpB = -1 * abs(cpidA) - 20000;
+  }
+
+  /* set cpid for channel B */
+
+  if (cpidB) cpB = cpidB;
+	
+  /* Calculate delay offsets
+     If stereo_offset is +ve A is later than B
+  */
+
+  if (stereo_offset > 0) {
+    delays[1] = 0;
+	delays[0] = stereo_offset / 10; /* remember stereo_offset is in usec */
+  } else {
+    delays[0] = 0;
+	delays[1] = (stereo_offset / 10) * (-1); /* stereo_offset is in usec */
+  }
+
+  mppulA = mppulB = 7;
+  mplgsA = mplgsB = 18;
+
+  txplA = (rsepA * 20) / 3;
+  txplB = (rsepB * 20) / 3;
+
+  /* just a dummy frequency */
+
+  tfreqA = 13500;
+  tfreqB = 14500; 
+
+  SiteSetupHardware();
+
+  /* remove invalid entries in the frequency band lists */
+
+  RemInvalidEntries(ifreqsA, ifreqsB);
+
+  /* determine the number of frequency bands */
+
+  FindNumBands(&numfreqbandsA, &numfreqbandsB, 
+               &day_nightA, &day_nightB, ifreqsA, ifreqsB, 1);
+
+  /* check beams */
+
+  if (low_beam_A  <  LOW_BEAM_A) low_beam_A  = LOW_BEAM_A;
+  if (high_beam_A > HIGH_BEAM_A) high_beam_A = HIGH_BEAM_A;
+
+  if (low_beam_B  <  LOW_BEAM_B) low_beam_B  = LOW_BEAM_B;
+  if (high_beam_B > HIGH_BEAM_B) high_beam_B = HIGH_BEAM_B;
+
+  /* end beams in the wrong order */
+
+  if (low_beam_A > high_beam_A) {
+    int beam = high_beam_A;
+    high_beam_A = low_beam_A;
+	low_beam_A  = beam;
+  }
+
+  if (low_beam_B > high_beam_B) {
+    int beam = high_beam_B;
+    high_beam_B = low_beam_B;
+	low_beam_B  = beam;
+  }
+
+  /* sort beam lists */
+
+  RemInvalidBeams(ibeamsA, ibeamsB);			
+  FindNumBeams(&numbeamsA, &numbeamsB, ibeamsA, ibeamsB, 1);
+
+  /*
+	the beam lists now contain:
+	1) the number of beams in the beam lists
+	2) if no beam list or camp beams were specified = 0 -> 15
+	3) if high and low beams were specified			= low_beam -> high_beam
+  */
+   
+  sprintf(progname,"stereoscan");
+
+  OpsFitACFStart();
+
+  OpsSetupTask(tasklist);
+  for (n=0;n<tnum;n++) {
+    RMsgSndReset(tlist[n]);
+    RMsgSndOpen(tlist[n],strlen(cmdlne),cmdlne);     
+  }
+
+  /* scan loop */
+
+  do {
+
+    if (SiteStartScan()==0) continue;
+
+    if (OpsReOpen(2,0,0) !=0) {
+      ErrLog(errlog,progname,"Opening new files.");
+      for (n=0;n<tnum;n++) {
+        RMsgSndClose(tlist[n]);
+        RMsgSndOpen(tlist[n],strlen(cmdlne),cmdlne);     
+      }
+    }
+
+    if (backward) scanA=scanB=-1;
+    else scanA=scanB=1; 
+
+    ErrLog(errlog,progname,"Starting scan.");
+
+
+    for (ibeamsA_index=0;ibeamsA_index<numbeamsA;ibeamsA_index++) {
+
+      bmnumA=ibeamsA[ibeamsA_index];
+      bmnumB=ibeamsB[ibeamsB_index];
+
+	  ifreqsAband = ifreqsA[ifreqsA_index];
+	  ifreqsBband = ifreqsB[ifreqsB_index];
+
+      TimeReadClock(&yr,&mo,&dy,&hr,&mt,&sc,&us);
+
+      if (day_nightA) { 
+        if (OpsDayNight()==1) {
+           stfrqA=usfreq[dfrqA];
+           frqrngA=ufreq_range[dfrqA];
+        } else {
+           stfrqA=usfreq[nfrqA];
+           frqrngA=ufreq_range[nfrqA];
+        } 
+      } else {
+        stfrqA=usfreq[ifreqsAband];
+        frqrngA=ufreq_range[ifreqsAband];
+      }
+
+      if (day_nightB) { 
+        if (OpsDayNight()==1) {
+           stfrqB=usfreq[dfrqB];
+           frqrngB=ufreq_range[dfrqB];
+        } else {
+           stfrqB=usfreq[nfrqB];
+           frqrngB=ufreq_range[nfrqB];
+        } 
+      } else {
+        stfrqB=usfreq[ifreqsBband];
+        frqrngB=ufreq_range[ifreqsBband];
+      }
+      fprintf(stderr,"setting beams\n");
+
+      SiteSetChannel(CHN_B);
+      SiteSetBeam(bmnumB);
+      SiteSetChannel(CHN_A);
+      SiteSetBeam(bmnumA);
+ 
+      SiteSetIntt(intsc,intus);
+      fprintf(stderr,"doing clear frequency search\n");
+
+//      stfrqA=13500;
+//      stfrqB=12500;
+//      frqrngA=300;
+//      frqrngB=300;
+
+      fprintf(stderr,"%d %d %d %d\n",stfrqA,frqrngA,stfrqB,frqrngB);
+
+      if (SiteFCLRS(stfrqA,stfrqA+frqrngA,stfrqB,
+                    stfrqB+frqrngB)==FREQ_LOCAL)
+        ErrLog(errlog,progname,"Frequency Synthesizer in local mode.");
+      fprintf(stderr,"back from clear frequency search\n");
+      if (tfreqA==-1) tfreqA=ftable->dfrq;
+      if (tfreqB==-1) tfreqB=ftable->dfrq;
+
+      sprintf(logtxt,"Channel A Transmitting on: %d (Noise=%g)",tfreqA,noiseA);
+      ErrLog(errlog,progname,logtxt);
+
+      sprintf(logtxt,"Channel B Transmitting on: %d (Noise=%g)",tfreqB,noiseB);
+      ErrLog(errlog,progname,logtxt);
+
+      SiteSetChannel(CHN_A);
+      SiteSetFreq(tfreqA);
+      SiteSetChannel(CHN_B);
+      SiteSetFreq(tfreqB);
+
+	  sprintf(logtxt,"Integrating:%2d,%2d intt:%d (%02d:%02d:%02d) %5d (%02d)  %5d (%02d) - %s  %d\n",
+		      bmnumA, bmnumB, intsc, hr, mt, 
+              sc, tfreqA, ifreqsAband, tfreqB, ifreqsBband, 
+              OpsDayNight() ? "day" : "night", abs(tfreqA - tfreqB));
+
+      ErrLog(errlog,progname,logtxt);
+
+      u_read_uconts();
+
+      txplA = (rsepA * 20) / 3;
+      txplB = (rsepB * 20) / 3;
+
+
+
+      tsgidA=SiteTimeSeqS(0,ptab);
+      tsgidB=SiteTimeSeqS(1,ptab);
+
+      SiteIntegrateS(lags,lags);   
+   
+
+      if (naveA<0) {
+        sprintf(logtxt,"Integration A failed:%d",naveA);
+        ErrLog(errlog,progname,logtxt); 
+        continue;
+      }
+      if (naveB<0) {
+        sprintf(logtxt,"Integration B failed:%d",naveB);
+        ErrLog(errlog,progname,logtxt); 
+        continue;
+      }
+
+      sprintf(logtxt,"Number of sequences: %d %d",naveA,naveB);
+      ErrLog(errlog,progname,logtxt);
+
+      OpsBuildRawS(0,&prmA,&rawA,ptab,lags);
+      OpsBuildRawS(1,&prmB,&rawB,ptab,lags);
+
+      FitACF(&prmA,&rawA,&fblk,&fitA);
+      FitACF(&prmB,&rawB,&fblk,&fitB);
+
+      ErrLog(errlog,progname,"Sending messages."); 
+  
+
+      msg.num=0;
+      msg.tsize=0;
+
+      RMsgSndAdd(&msg,sizeof(struct RadarParm),(unsigned char *) &prmA,
+		PRM_TYPE,0); 
+      RMsgSndAdd(&msg,sizeof(struct RawData),(unsigned char *) &rawA,
+		RAW_TYPE,0);    
+
+      RMsgSndAdd(&msg,sizeof(struct FitData),(unsigned char *) &fitA,
+		FIT_TYPE,0);
+
+      RMsgSndAdd(&msg,strlen(progname)+1,progname,
+		NME_TYPE,0);   
+
+      RMsgSndAdd(&msg,sizeof(struct RadarParm),(unsigned char *) &prmB,
+		PRM_TYPE,1); 
+      RMsgSndAdd(&msg,sizeof(struct RawData),(unsigned char *) &rawB,
+		RAW_TYPE,1);    
+
+      RMsgSndAdd(&msg,sizeof(struct FitData),(unsigned char *) &fitB,
+		FIT_TYPE,1);
+
+   
+      RMsgSndAdd(&msg,strlen(progname)+1,progname,
+		NME_TYPE,1);   
+ 
+
+      for (n=0;n<tnum;n++) RMsgSndSend(tlist[n],&msg); 
+  
+      ErrLog(errlog,progname,"Polling for exit."); 
+ 
+      exitpoll=RadarShell(sid,&rstable);
+
+	  /* check the bands and beams here, after radar shell */
+
+	  RemInvalidBeams(ibeamsA, ibeamsB);			
+	  FindNumBeams(&numbeamsA, &numbeamsB, ibeamsA, ibeamsB, 0);
+
+	  RemInvalidEntries(ifreqsA, ifreqsB);
+	  FindNumBands(&numfreqbandsA, &numfreqbandsB, &day_nightA, &day_nightB, ifreqsA, ifreqsB, 0);
+
+	  if (ifreqsA_index >= numfreqbandsA) ifreqsA_index = 0;
+	  if (ifreqsB_index >= numfreqbandsB) ifreqsB_index = 0;
+  
+	  /* Calculate delay offsets if stereo offset has been changed
+         If stereo_offset is +ve A is later than B
+       */
+
+	  if (stereo_offset > 0) {
+	    delays[1] = 0;
+		delays[0] = stereo_offset / 10; /* stereo_offset is in usec */
+ 	  } else {
+		delays[0] = 0;
+		delays[1] = (stereo_offset / 10) * (-1); /* stereo_offset is in usec */
+	  }
+
+	  if (exitpoll !=0) break;
+
+	  scanA = 0;
+	  scanB = 0;
+
+	  /* change beam number index */
+
+	  ibeamsB_index++;
+
+	  if (ibeamsB_index >= numbeamsB) ibeamsB_index = 0;
+
+	  /* change band at the end of channel B scan */
+
+	  if (ibeamsB_index == 0) {
+	    if (numfreqbandsB != 0) {
+		  ifreqsB_index++;
+          if (ifreqsB_index >= numfreqbandsB) ifreqsB_index = 0;
+		}
+	  }
+    } 
+    
+	/* increment individual frequency band index. Doesn't matter whether
+	   individual frequency bands are being used for this channel or not.
+     */
+
+    if (numfreqbandsA != 0) {
+      ifreqsA_index++;
+      if (ifreqsA_index >= numfreqbandsA) ifreqsA_index = 0;
+    }
+
+    ErrLog(errlog,progname,"Waiting for scan boundary."); 
+    if ((scnsc !=0) || (scnus !=0)) {
+      if (exitpoll==0) OpsWaitBoundary(scnsc,scnus);
+    }
+  } while (exitpoll==0);
+  SiteEnd();
+  for (n=0;n<tnum;n++) RMsgSndClose(tlist[n]);
+  ErrLog(errlog,progname,"Ending program.");
+  RShellTerminate(sid);
+  return 0;   
+} 
+ 
+
+/***************************************************************************/
+
+/* Sets up the licenced frequency bands for Iceland, Finland and Blackstone */
+
+void u_init_freq_bands() {
+
+/* start freq of each band */
+
+   /* Finland */
+
+   usfreq[0] = 8305;
+   usfreq[1] = 8965;
+   usfreq[2] = 9900;
+   usfreq[3] = 11075;
+   usfreq[4] = 11550;
+   usfreq[5] = 12370;
+   usfreq[6] = 13200;
+   usfreq[7] = 15010;
+   usfreq[8] = 16210;
+   usfreq[9] = 16555;
+   usfreq[10] = 17970;
+   usfreq[11] = 18850;
+   usfreq[12] = 19415;
+   usfreq[13] = 19705;
+   usfreq[14] = 19800;
+
+   /* Iceland */
+
+   usfreq[20] = 8000;
+   usfreq[21] = 8430;
+   usfreq[22] = 8985;
+   usfreq[23] = 10155;
+   usfreq[24] = 10655;
+   usfreq[25] = 11290;
+   usfreq[26] = 11475;
+   usfreq[27] = 12105;
+   usfreq[28] = 12305;
+   usfreq[29] = 12590;
+   usfreq[30] = 13360;
+   usfreq[31] = 13875;
+   usfreq[32] = 14400;
+   usfreq[33] = 15805;
+   usfreq[34] = 16500;
+   usfreq[35] = 16820;
+   usfreq[36] = 18175;
+   usfreq[37] = 18835;
+   usfreq[38] = 19910;
+   usfreq[39] = 10155;
+
+   /* Blackstone */
+	/* Ray's preferred bands*/
+	usfreq[40] = 9400;
+	usfreq[41] = 10210;
+	usfreq[42] = 10710;
+	usfreq[43] = 12500;
+	usfreq[44] = 13470;
+	usfreq[45] = 14410;
+
+	/* bands that allow the whole licenced range to be used*/
+	/* each band approx 500kHz wide */
+	usfreq[50] = 9000;
+	usfreq[51] = 9470;
+	usfreq[52] = 10210;
+	usfreq[53] = 10710;
+	usfreq[54] = 11460;
+	usfreq[55] = 12040;
+	usfreq[56] = 12620;
+	usfreq[57] = 13470;
+	usfreq[58] = 14410;
+	usfreq[59] = 15070;
+	usfreq[60] = 15620;
+	usfreq[61] = 16170;
+	usfreq[62] = 16720;
+	usfreq[63] = 17270;
+	/* these bands are wider than 500kHz */
+	usfreq[64] = 9000;
+	usfreq[65] = 10210;
+	usfreq[66] = 11460;
+	usfreq[67] = 15070;
+
+   /* width of each band */
+
+   /* Finland */
+
+   ufreq_range[0] = 30;
+   ufreq_range[1] = 75;
+   ufreq_range[2] = 85;
+   ufreq_range[3] = 200;
+   ufreq_range[4] = 50;
+   ufreq_range[5] = 45;
+   ufreq_range[6] = 60;
+   ufreq_range[7] = 70;
+   ufreq_range[8] = 150;
+   ufreq_range[9] = 60;
+   ufreq_range[10] = 80;
+   ufreq_range[11] = 15;
+   ufreq_range[12] = 265;
+   ufreq_range[13] = 50;
+   ufreq_range[14] = 190; 
+
+   /* Iceland */
+
+   ufreq_range[20] = 195;
+   ufreq_range[21] = 420;
+   ufreq_range[22] = 410;
+   ufreq_range[23] = 500;
+   ufreq_range[24] = 520;
+   ufreq_range[25] = 160;
+   ufreq_range[26] = 120;
+   ufreq_range[27] = 130;
+   ufreq_range[28] = 205;
+   ufreq_range[29] = 690;
+   ufreq_range[30] = 205;
+   ufreq_range[31] = 120;
+   ufreq_range[32] = 615;
+   ufreq_range[33] = 560;
+   ufreq_range[34] = 185;
+   ufreq_range[35] = 655;
+   ufreq_range[36] = 595;
+   ufreq_range[37] = 50;
+   ufreq_range[38] = 90;
+   ufreq_range[39] = 1020;
+
+   /* Blackstone */
+   ufreq_range[40] = 500;
+   ufreq_range[41] = 500;
+   ufreq_range[42] = 500;
+   ufreq_range[43] = 500;
+   ufreq_range[44] = 470;
+   ufreq_range[45] = 500;
+
+   ufreq_range[50] = 470;
+   ufreq_range[51] = 465;
+   ufreq_range[52] = 500;
+   ufreq_range[53] = 505;
+   ufreq_range[54] = 580;
+   ufreq_range[55] = 580;
+   ufreq_range[56] = 580;
+   ufreq_range[57] = 470;
+   ufreq_range[58] = 520;
+   ufreq_range[59] = 550;
+   ufreq_range[60] = 550;
+   ufreq_range[61] = 550;
+   ufreq_range[62] = 550;
+   ufreq_range[63] = 570;
+   ufreq_range[64] = 935;
+   ufreq_range[65] = 1005;
+   ufreq_range[66] = 1740;
+   ufreq_range[67] = 2770;
+
+
+}
+
+/* Sends a proxy message to the microcontroller monitoring 
+   task every beam.
+*/
+
+void u_read_uconts() {
+  if (uucont_proxy != 0) Trigger(uucont_proxy);
+}
+
+
+
+/* remove invalid entries in the frequency band lists */
+
+void RemInvalidEntries(int ifreqsA[NUMBANDS], int ifreqsB[NUMBANDS]) {
+  int i, j;
+
+  for (i = NUMBANDS - 1; i > 0; i--) {
+
+	/* if the preceding element is -1 then move all the following
+	   bands down
+     */
+
+	if ((ifreqsA[i] != -1) && (ifreqsA[i - 1] == -1)) {
+	  for (j = i; j < NUMBANDS; j++) {
+	    ifreqsA[j - 1] = ifreqsA[j];
+		ifreqsA[j] = -1;
+	  }
+	}
+
+	if ((ifreqsB[i] != -1) && (ifreqsB[i - 1] == -1)) {
+	  for (j = i; j < NUMBANDS; j++) {
+	    ifreqsB[j - 1] = ifreqsB[j];
+		ifreqsB[j] = -1;
+	  }
+	}
+  }
+}
+
+/* determine the number of frequency bands */
+
+void FindNumBands(int *numfreqbandsA, int *numfreqbandsB, 
+                  int *day_nightA, int *day_nightB, 
+                  int ifreqsA[NUMBANDS], int ifreqsB[NUMBANDS], 
+                  int print) {
+  int i;
+  char logtxt[256];
+
+  *numfreqbandsA = 0;
+  *numfreqbandsB = 0;
+
+  for (i = 0; i < NUMBANDS; i++) {
+    if (ifreqsA[i] != -1) (*numfreqbandsA)++;
+	if (ifreqsB[i] != -1) (*numfreqbandsB)++;
+  }
+
+  /* check to see if day/night frequencies are to be used */
+
+  if (*numfreqbandsA != 0) *day_nightA = 0;
+  else *day_nightA = 1;
+
+  if (*numfreqbandsB != 0) *day_nightB = 0;
+  else *day_nightB = 1;
+
+  if (print) {
+    sprintf(logtxt, "Channel A: %d  Channel B: %d", *numfreqbandsA, 
+            *numfreqbandsB);
+	ErrLog(errlog, progname, logtxt);
+  }
+
+  /* print frequency bands for each channel */
+
+  if ((*numfreqbandsA > 0) && print) {
+    ErrLog(errlog,progname,"Frequency bands for channel A: ");
+
+    for (i = 0; i < *numfreqbandsA; i++) {
+	  sprintf(logtxt, "%1d ", ifreqsA[i]);
+	  ErrLog(errlog,progname,logtxt);
+	}
+  }
+
+  if ((*numfreqbandsB > 0) && print) {
+    ErrLog(errlog,progname,"Frequency bands for channel B: ");
+
+	for (i = 0; i < *numfreqbandsB; i++) {
+	  sprintf(logtxt, "%1d ", ifreqsB[i]);
+	  ErrLog(errlog,progname,logtxt);
+	}
+  }
+}
+
+/* remove invalid entries in the beam lists */
+
+void RemInvalidBeams(int ibeamsA[NUMBEAMS], int ibeamsB[NUMBEAMS]) {
+  int i, j;
+
+  for (i = NUMBEAMS - 1; i > 0; i--) {
+    if (ibeamsA[i] <  0) ibeamsA[i] = -1;
+	if (ibeamsA[i] > 15) ibeamsA[i] = -1;
+
+	if (ibeamsB[i] <  0) ibeamsB[i] = -1;
+	if (ibeamsB[i] > 15) ibeamsB[i] = -1;
+  }
+
+  for (i = NUMBEAMS - 1; i > 0; i--) {
+
+	/* if the preceding element is -1 then move all the 
+       following beams down
+     */
+
+	if ((ibeamsA[i - 1] == -1) && (ibeamsA[i] != -1)) {
+	  for (j = i; j < NUMBEAMS; j++) {
+	    ibeamsA[j - 1] = ibeamsA[j];
+		ibeamsA[j] = -1;
+	  }
+	}
+
+	if ((ibeamsB[i - 1] == -1) && (ibeamsB[i] != -1)) {
+	  for (j = i; j < NUMBEAMS; j++) {
+	    ibeamsB[j - 1] = ibeamsB[j];
+		ibeamsB[j] = -1;
+	  }
+	}
+  }
+}
+
+/* determine the number of beams */
+
+void FindNumBeams(int *numbeamsA, int *numbeamsB, 
+                  int ibeamsA[NUMBEAMS], int ibeamsB[NUMBEAMS], 
+                  int print) {
+  int i;
+  char logtxt[256];
+
+  *numbeamsA = 0;
+  *numbeamsB = 0;
+
+  /* count channel A beams */
+
+  for (i = 0; i < NUMBEAMS; i++) {
+    if (ibeamsA[i] != -1) (*numbeamsA)++;
+	else break;
+  }
+
+  /* count channel B beams */
+
+  for (i = 0; i < NUMBEAMS; i++) {
+    if (ibeamsB[i] != -1) (*numbeamsB)++;
+	else break;
+  }
+
+  if (print) {
+    sprintf(logtxt, "Beams A: %d  Beams B: %d", *numbeamsA, *numbeamsB);
+	ErrLog(errlog, progname, logtxt);
+
+	/* print frequency bands for each channel */
+
+	if (*numbeamsA > 0) {
+	  ErrLog(errlog,progname,"Beams for channel A: ");
+
+	  for (i = 0; i < *numbeamsA; i++) {
+	    sprintf(logtxt, "%1d ", ibeamsA[i]);
+	    ErrLog(errlog,progname,logtxt);
+	  }
+	}
+
+	if (*numbeamsB > 0) {
+	  ErrLog(errlog,progname,"Beams for channel B: ");
+       for (i = 0; i < *numbeamsB; i++) {
+	     sprintf(logtxt, "%1d ", ibeamsB[i]);
+		 ErrLog(errlog,progname,logtxt);
+	   }
+	}
+  }
+
+  /* if no beams have been specified fill the arrays with normal sequence
+     between low_beam and high beam.  
+   */
+  
+  if (*numbeamsA == 0) {
+    if (backward) {
+      for (i = 0; i < (high_beam_A - low_beam_A + 1); i++) {
+        ibeamsA[i] = high_beam_A - i;
+        (*numbeamsA)++;
+ 	  }
+    } else {
+ 	  for (i = 0; i < (high_beam_A - low_beam_A + 1); i++) {
+	    ibeamsA[i] = low_beam_A + i;
+        (*numbeamsA)++;
+	  }
+    }
+  }
+
+  if (*numbeamsB == 0) {
+
+	if (backward) {
+      for (i = 0; i < (high_beam_B - low_beam_B + 1); i++) {
+  	    ibeamsB[i] = high_beam_B - i;
+        (*numbeamsB)++;
+	  }
+    } else {
+  	  for (i = 0; i < (high_beam_B - low_beam_B + 1); i++) {
+        ibeamsB[i] = low_beam_B + i;
+        (*numbeamsB)++;
+	  }
+    }
+  }
+}
+
+
+
+

--- a/qnx4/sd_leicester/pyk/stereoscan.1.04/stereoscan.c.orig
+++ b/qnx4/sd_leicester/pyk/stereoscan.1.04/stereoscan.c.orig
@@ -1,0 +1,1271 @@
+/* stereoscan.c
+   ============
+   Author: R.J.Barnes
+*/
+
+/*
+ Copyright 2004 The Johns Hopkins University/Applied Physics Laboratory.
+ All rights reserved.
+ 
+ This material may be used, modified, or reproduced by or for the U.S.
+ Government pursuant to the license rights granted under the clauses at DFARS
+ 252.227-7013/7014.
+ 
+ For any other permissions, please contact the Space Department
+ Program Office at JHU/APL.
+ 
+ This Distribution and Disclaimer Statement must be included in all copies of
+ "Radar Operating System - Control Programs" (hereinafter "the Program").
+ 
+ The Program was developed at The Johns Hopkins University/Applied Physics
+ Laboratory (JHU/APL) which is the author thereof under the "work made for
+ hire" provisions of the copyright law.  
+ 
+ JHU/APL assumes no obligation to provide support of any kind with regard to
+ the Program.  This includes no obligation to provide assistance in using the
+ Program or to provide updated versions of the Program.
+ 
+ THE PROGRAM AND ITS DOCUMENTATION ARE PROVIDED AS IS AND WITHOUT ANY EXPRESS
+ OR IMPLIED WARRANTIES WHATSOEVER.  ALL WARRANTIES INCLUDING, BUT NOT LIMITED
+ TO, PERFORMANCE, MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE ARE
+ HEREBY DISCLAIMED.  YOU ASSUME THE ENTIRE RISK AND LIABILITY OF USING THE
+ PROGRAM TO INCLUDE USE IN COMPLIANCE WITH ANY THIRD PARTY RIGHTS.  YOU ARE
+ ADVISED TO TEST THE PROGRAM THOROUGHLY BEFORE RELYING ON IT.  IN NO EVENT
+ SHALL JHU/APL BE LIABLE FOR ANY DAMAGES WHATSOEVER, INCLUDING, WITHOUT
+ LIMITATION, ANY LOST PROFITS, LOST SAVINGS OR OTHER INCIDENTAL OR
+ CONSEQUENTIAL DAMAGES, ARISING OUT OF THE USE OR INABILITY TO USE THE
+ PROGRAM."
+ 
+ 
+ 
+ 
+ 
+  
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/types.h>
+#include <sys/proxy.h>
+#include <sys/kernel.h>
+#include <string.h>
+#include <time.h>
+#include "rtypes.h"
+#include "option.h"
+#include "rtime.h"
+#include "limit.h"
+#include "radar.h"
+#include "rprm.h"
+#include "rawdata.h"
+#include "fitblk.h"
+#include "fitdata.h"
+#include "fitacf.h"
+
+#include "taskid.h"
+#include "errlog.h"
+#include "freq.h"
+#include "rmsg.h"
+#include "radarshell.h"
+#include "rmsgsnd.h"
+#include "tsg.h"
+#include "tsgtable.h"
+#include "maketsg.h"
+#include "global.h"
+#include "globals.h"
+#include "setup.h"
+#include "reopen.h"
+#include "tmseq.h"
+#include "raws.h"
+#include "sync.h"
+#include "interface.h"
+#include "hdw.h"
+
+/*
+ $Log: stereoscan.c,v $
+ Revision 1.4  2007/08/09 14:09:51  code
+ Allowed command lines to be passed as a file.
+
+ Revision 1.3  2007/08/08 16:55:44  code
+ Fixed bug in using hex notation for stid.
+
+ Revision 1.2  2006/07/12 15:51:43  code
+ Added call to set up command line and limited data written to rawacf and fitacf.
+
+ Revision 1.1  2006/03/30 11:19:18  barnes
+ Initial revision
+ 
+*/
+
+/*
+	Modified 10/12/2001 PH
+
+	Added bnA and bnB frequency band options to cycle through frequency
+	bands during each scan. No check is made for invalid band numbers.
+	A band number of -1 is ignored. Bands can be added/removed at any
+	time using radar_shell, changes won't take effect until the end of
+	the current scan. If no band numbers are specified, normal day/night
+	frequencies are used.
+
+	Frequency bands can also be specified for campA and campB modes.
+
+	Extra options can be placed in a separate schedule file. The file
+	name should be the last argument in the schedule argument list and
+	should include the full path.
+
+	Modified 16/01/02 PH
+
+	Fixed synchronisation bug. The code wasn't subtracting the time taken
+	for a clear frequency search from the beam integration time, resulting
+	in an extended beam dwell time and a sweep lasting for more than 60 s
+	for fast stereo and 120 s for slow stereo 7 s integration.
+
+	Standard slow stereo (normal stereo) is now 7 seconds (by Mark Lester).
+
+	Modified 30/01/02 PH
+
+	added -cts? options that pre-set other options
+
+			dwell	chan A	cpidA	chan B	cpidB	Ice/Fin	offset	range
+			------	------	------	------	------	------- ------	-----
+	cts2 -    7		normal	 152	 tbj	-26002	 5 / 9	 +400	 45
+	cts4 -	  7		normal	 152	normal	-26004	 5 / 9	 +400	 45
+	cts6 -	  7		normal	 152	1 camp	-26006	 5 / 9	 +400	 45
+	cts8 -	  7		normal	 152	2 camp	-26008	 5 / 9	 +400	 45
+
+	cts3 -	  3		normal	 153	 tbj	-26003	 5 / 9	 +400	 45
+	cts5 -	  3		normal	 153	normal	-26005	 5 / 9	 +400	 45
+	cts7 -	  3		normal	 153	1 camp	-26007	 5 / 9	 +400	 45
+	cts9 -	  3		normal	 153	2 camp	-26009	 5 / 9	 +400	 45
+
+	Single camp beams are hard coded to the standard Finland beam 9 and
+	Iceland beam 5.
+
+	Double camp beams are the same for both radars and defined as
+	DOUBLE_CAMP_LOW and DOUBLE_CAMP_HIGH.
+
+	range gates and first range are let to the default settings of 45km
+	and 180km respectively.
+
+	specifying any cts option will override low and high beam, offset, cpIDs,
+	integration time and scan boundary. tbj mode overrides frequencies.
+
+	Modified 05/04/02 PH
+
+	Uses the new stereo aware version of fitacf (1.06).
+
+	Modified 30/04/2002 PH
+
+	Added cpidA and cpidB to set the cpid. This option overrides any
+	previously defined cpid.
+
+	Added bmnA and bmnB to cycle through beams numbers on both channels.
+	To specify double camp beams use -bm0B 5 -bm1B 9
+	To specify single camp beams use -bm0B 5
+	The same beam number can be specified more than once.
+	The number of beams in the channel A beam list determines the number of
+	beams per scan. This is important if you are also using frequency lists.
+
+	cts 2, 3, 4, 5 beams patterns can be changed with bm*A and bm*B options.
+
+	Modified 25/09/02 PH
+
+	Changed so that the B channel frequency band changes at the end of the
+	channel B scan, so that it is independent of the number of beams on
+	channel A.
+
+  Modified 7th Dec 2001 to add camp beam flags
+  Modified 23 Nov 2001 to add new -ns and -fs flags and changed some defaults
+  Modified 10th Aug to account for backwards scanning radars
+  Modified 8th Aug fitacf_s
+  Julian modified version. March 2001
+
+*/
+
+#define CPID_A -6401
+#define CPID_B -26401
+#define CPID_NS 152
+#define CPID_FS 153
+
+
+#define INTT      7
+#define RSEP_A 45
+#define RSEP_B 45
+#define FRANG_A 180
+#define FRANG_B 180
+
+
+#define LOW_BEAM_A   0
+#define HIGH_BEAM_A  15
+#define LOW_BEAM_B   0
+#define HIGH_BEAM_B  15
+
+#define SINGLE_CAMP_BEAM_PYK 5
+#define SINGLE_CAMP_BEAM_HAN 9
+
+
+#define DOUBLE_CAMP_LOW 5
+#define DOUBLE_CAMP_HIGH 9
+
+#define UCONT_NAME "ucont_moni"
+
+#define CHN_A 0
+#define CHN_B 1
+
+#define NUMBANDS 10
+#define NUMBEAMS 16
+
+
+#define SCHEDULER "schedule"
+#define ERRLOG "errlog"
+
+#define CONTROL_NAME "control_program"
+#define TASK_NAMES "echo_data","rawacfwrite","fitacfwrite"
+
+
+
+void u_read_uconts(void);
+void u_init_freq_bands(void);
+
+void RemInvalidEntries(int ifreqsA[], int ifreqsB[]);
+void FindNumBands(int *numfreqbandsA, int *numfreqbandsB, int *day_nightA, int *day_nightB, int ifreqsA[], int ifreqsB[], int print);
+void RemInvalidBeams(int ibeamsA[], int ibeamsB[]);
+void FindNumBeams(int *numbeamsA, int *numbeamsB, int ibeamsA[], int ibeamsB[], int print);
+
+char cmdlne[1024];
+char progid[80]={"$Id: stereoscan.c,v 1.4 2007/08/09 14:09:51 code Exp $"};
+char progname[256];
+struct TaskID *errlog;
+
+int usfreq[42];
+int ufreq_range[42];
+
+pid_t uucont_proxy;
+
+int low_beam_A=LOW_BEAM_A;
+int high_beam_A=HIGH_BEAM_A;
+int low_beam_B=LOW_BEAM_B;
+int high_beam_B=HIGH_BEAM_B;
+
+
+
+
+char *tasklist[]=
+ { TASK_NAMES,
+  0};
+
+int arg=0;
+struct OptionData opt;
+struct OptionFile *optf=NULL;
+      
+int main(int argc,char *argv[]) {
+
+  int ptab[7] = {0,9,12,20,22,26,27};
+
+  int lags[LAG_SIZE][2] = {
+    { 0, 0},		/*  0 */
+    {26,27},		/*  1 */
+    {20,22},		/*  2 */
+    {9,12},		/*  3 */
+    {22,26},		/*  4 */
+    {22,27},		/*  5 */
+
+    {20,26},		/*  7 */
+    {20,27},		/*  8 */
+    {0,9},		/*  9 */
+    {12,22},		/* 10 */
+    {9,20},		/* 11 */
+    {0,12},	  	    /* 12 */
+    {9,22},		/* 13 */
+    {12,26},		/* 14 */
+    {12,27},		/* 15 */
+    {9,26},		/* 16 */
+    {9,27},		/* 17 */
+    {27,27}};		/* alternate lag-0  */
+
+
+  char *sname=NULL;
+  char *ename=NULL;
+  char *sdname={SCHEDULER};
+  char *edname={ERRLOG};
+  char logtxt[1024];
+
+  char a[10];
+
+  int n,i;
+  pid_t sid;
+  int exitpoll=0;
+ 
+  int scnsc=0;
+  int scnus=0;
+ 
+  unsigned char ns=0;
+  unsigned char fs=0;
+
+  int stereo_offset=400; /* channel A delayed by this 
+                            number of microseconds */
+
+
+  int ifreqsA[NUMBANDS],ifreqsB[NUMBANDS];
+
+  int ibeamsA[NUMBEAMS],ibeamsB[NUMBEAMS];
+
+  int day_nightA=1;
+  int day_nightB=1;
+
+  int numfreqbandsA;
+  int numfreqbandsB;
+  
+  int ifreqsA_index=0; 
+  int ifreqsB_index=0;
+  
+  int ifreqsAband;
+  int ifreqsBband;
+
+  int numbeamsA,numbeamsB;
+
+  int ibeamsA_index=0;
+  int ibeamsB_index=0;
+
+  unsigned char cts2=0,cts4=0,cts6=0,cts8=0;
+  unsigned char cts3=0,cts5=0,cts7=0,cts9=0;
+  
+  int cpidA=0,cpidB=0;
+
+  for (i=0;i<NUMBANDS;i++) ifreqsA[i]=ifreqsB[i]=-1;
+  for (i=0;i<NUMBEAMS;i++) ibeamsA[i]=ibeamsB[i]=-1;
+  
+  xcfA=xcfB=1;
+ 
+  cpA=CPID_A;
+  cpB=CPID_B;
+
+  SiteStart();
+ 
+  intsc=INTT;
+  intus=0;
+ 
+  maxattenA=maxattenB=7;
+
+  if ((uucont_proxy=SiteInitProxy(UCONT_NAME))==-1) {
+    perror("cannot attach proxy");
+  }
+ 
+  u_init_freq_bands();
+  
+  strcpy(cmdlne,argv[0]);
+  for (n=1;n<argc;n++) {
+    strcat(cmdlne," ");
+    strcat(cmdlne,argv[n]);
+  } 
+
+  strncpy(combf,progid,80);   
+  OpsSetupCommand(argc,argv);
+  OpsSetupRadar();
+  OpsSetupShell();
+
+  RadarShellAdd(&rstable,"intt",var_LONG,&intsc);
+  RadarShellAdd(&rstable,"inttsc",var_LONG,&intsc);
+  RadarShellAdd(&rstable,"inttus",var_LONG,&intus);
+
+  RadarShellAdd(&rstable,"txplA",var_LONG,&txplA);
+  RadarShellAdd(&rstable,"mpincA",var_LONG,&mpincA);
+  RadarShellAdd(&rstable,"mppulA",var_LONG,&mppulA);
+  RadarShellAdd(&rstable,"mplgsA",var_LONG,&mplgsA);
+  RadarShellAdd(&rstable,"nrangA",var_LONG,&nrangA);
+  RadarShellAdd(&rstable,"frangA",var_LONG,&frangA);
+  RadarShellAdd(&rstable,"rsepA",var_LONG,&rsepA);
+  RadarShellAdd(&rstable,"bmnumA",var_LONG,&bmnumA);
+  RadarShellAdd(&rstable,"xcfA",var_LONG,&xcfA);
+  RadarShellAdd(&rstable,"tfreqA",var_LONG,&tfreqA);
+  RadarShellAdd(&rstable,"scanA",var_LONG,&scanA);
+  RadarShellAdd(&rstable,"mxpwrA",var_LONG,&mxpwrA);
+  RadarShellAdd(&rstable,"lvmaxA",var_LONG,&lvmaxA);
+  RadarShellAdd(&rstable,"rxriseA",var_LONG,&rxriseA);
+  RadarShellAdd(&rstable,"combfA",var_STRING,combfA);
+  RadarShellAdd(&rstable,"cpA",var_LONG,&cpA);
+
+  RadarShellAdd(&rstable,"txplB",var_LONG,&txplB);
+  RadarShellAdd(&rstable,"mpincB",var_LONG,&mpincB);
+  RadarShellAdd(&rstable,"mppulB",var_LONG,&mppulB);
+  RadarShellAdd(&rstable,"mplgsB",var_LONG,&mplgsB);
+  RadarShellAdd(&rstable,"nrangB",var_LONG,&nrangB);
+  RadarShellAdd(&rstable,"frangB",var_LONG,&frangB);
+  RadarShellAdd(&rstable,"rsepB",var_LONG,&rsepB);
+  RadarShellAdd(&rstable,"bmnumB",var_LONG,&bmnumB);
+  RadarShellAdd(&rstable,"xcfB",var_LONG,&xcfB);
+  RadarShellAdd(&rstable,"tfreqB",var_LONG,&tfreqB);
+  RadarShellAdd(&rstable,"scanB",var_LONG,&scanB);
+  RadarShellAdd(&rstable,"mxpwrB",var_LONG,&mxpwrB);
+  RadarShellAdd(&rstable,"lvmaxB",var_LONG,&lvmaxB);
+  RadarShellAdd(&rstable,"rxriseB",var_LONG,&rxriseB);
+  RadarShellAdd(&rstable,"combfB",var_STRING,combfB);
+  RadarShellAdd(&rstable,"cpB",var_LONG,&cpB);
+
+  OptionAdd(&opt, "ns",	'x', &ns);
+  OptionAdd(&opt, "fs",	'x', &fs);
+  OptionAdd(&opt, "e",	't', &ename);  
+  OptionAdd(&opt, "sc",	't', &sname);
+  OptionAdd(&opt, "intt",	'i', &intsc);
+  OptionAdd(&opt, "dfA",	'i', &dfrqA);
+  OptionAdd(&opt, "dfB",	'i', &dfrqB);
+  OptionAdd(&opt, "nfA",	'i', &nfrqA);
+  OptionAdd(&opt, "nfB",	'i', &nfrqB);
+  
+  OptionAdd(&opt, "offset",	'i',&stereo_offset);
+
+  OptionAdd(&opt, "frA",	'i', &frangA);
+  OptionAdd(&opt, "frB",	'i', &frangB);
+  OptionAdd(&opt, "rgA",	'i', &rsepA);
+  OptionAdd(&opt, "rgB",	'i', &rsepB);
+  OptionAdd(&opt, "lbA",	'i', &low_beam_A);
+  OptionAdd(&opt, "hbA",	'i', &high_beam_A);
+  OptionAdd(&opt, "lbB",	'i', &low_beam_B);
+  OptionAdd(&opt, "hbB",	'i', &high_beam_B);
+  OptionAdd(&opt, "sp",	'i', &scnsc);
+
+  OptionAdd(&opt, "cpidA", 'i', &cpidA);
+  OptionAdd(&opt, "cpidB", 'i', &cpidB);
+
+  /* set up remaining shell variables */
+
+  RadarShellAdd(&rstable, "dfA",var_LONG,&dfrqA);
+  RadarShellAdd(&rstable, "dfB",var_LONG,&dfrqB);
+  RadarShellAdd(&rstable, "nfA",var_LONG,&nfrqA);
+  RadarShellAdd(&rstable, "nfB",var_LONG,&nfrqB);
+
+  RadarShellAdd(&rstable, "offset",	var_LONG,&stereo_offset);
+ 
+  RadarShellAdd(&rstable, "low_beamA",	var_LONG,&low_beam_A);
+  RadarShellAdd(&rstable, "high_beamA",var_LONG,&high_beam_A);
+  RadarShellAdd(&rstable, "low_beamB",	var_LONG,&low_beam_B);
+  RadarShellAdd(&rstable, "high_beamB",var_LONG,&high_beam_B);
+  RadarShellAdd(&rstable, "scan_period",var_LONG,&scnsc);
+
+  /* add new options - individual frequency bands */
+
+  strcpy(a,"b0A");
+  for (i = 0; i < NUMBANDS; i++) {
+    a[1] = '0' + i; /* change 2nd char to ACSII number */
+    OptionAdd(&opt, a,	'i', &ifreqsA[i]);
+    RadarShellAdd(&rstable, a, var_LONG, &ifreqsA[i]);
+  }
+
+  strcpy(a,"b0B");
+  for (i = 0; i < NUMBANDS; i++) {
+    a[1] = '0' + i; /* change 2nd char to ACSII number */
+    OptionAdd(&opt, a,	'i', &ifreqsB[i]);
+    RadarShellAdd(&rstable, a, var_LONG, &ifreqsB[i]);
+  }
+
+  strcpy(a,"bm0A");
+  
+  for (i = 0; i < 10; i++) {
+    a[2] = '0' + i;  /* change 3nd char to ACSII number */
+    OptionAdd(&opt, a,	'i', &ibeamsA[i]);
+    RadarShellAdd(&rstable, a, var_LONG, &ibeamsA[i]);
+  }
+
+  strcpy(a,"bm10A");
+  for (i = 0; i < 6; i++) {
+    a[3] = '0' + i;  /* change 4nd char to ACSII number */
+    OptionAdd(&opt, a,	'i', &ibeamsA[i + 10]);
+    RadarShellAdd(&rstable, a, var_LONG, &ibeamsA[i + 10]);
+  }
+
+  strcpy(a,"bm0B");
+  for (i = 0; i < 10; i++) {
+    a[2] = '0' + i;  /* change 3nd char to ACSII number */
+    OptionAdd(&opt, a,	'i', &ibeamsB[i]);
+    RadarShellAdd(&rstable, a, var_LONG, &ibeamsB[i]);
+  }
+
+  strcpy(a,"bm10B");
+  for (i = 0; i < 6; i++) {
+    a[3] = '0' + i; /* change 4nd char to ACSII number */
+    OptionAdd(&opt, a,	'i', &ibeamsB[i + 10]);
+    RadarShellAdd(&rstable, a, var_LONG, &ibeamsB[i + 10]);
+  }
+
+  /* add CTs options */
+
+  OptionAdd(&opt, "cts2", 'x', &cts2);
+  OptionAdd(&opt, "cts3", 'x', &cts3);
+  OptionAdd(&opt, "cts4", 'x', &cts4);
+  OptionAdd(&opt, "cts5", 'x', &cts5);
+  OptionAdd(&opt, "cts6", 'x', &cts6);
+  OptionAdd(&opt, "cts7", 'x', &cts7);
+  OptionAdd(&opt, "cts8", 'x', &cts8);
+  OptionAdd(&opt, "cts9", 'x', &cts9);
+ 
+  arg=OptionProcess(1,argc,argv,&opt,NULL); 
+
+  if (arg<argc) {
+    int farg;
+    FILE *fp=NULL;
+    fp=fopen(argv[arg],"r");
+    if (fp!=NULL) {
+      optf=OptionProcessFile(fp);
+      if (optf !=NULL) {
+        farg=OptionProcess(0,optf->argc,optf->argv,&opt,NULL);
+        OptionFreeFile(optf);
+      }   
+      fclose(fp);
+    }
+  }
+ 
+  if (sname==NULL) sname=sdname;
+  if (ename==NULL) ename=edname;
+
+  sid=RShellRegister(sname,CONTROL_NAME);
+
+  errlog=TaskIDMake(ename);  
+  OpsLogStart(errlog,progname,argc,argv);  
+
+  /* handle CTs */
+
+  if ((cts2) || (cts4) || (cts6) || (cts8)) {
+    cpA = 152;
+	intsc = 7;
+    intus = 0;
+    stereo_offset = 400;
+    scnsc = 120;
+    scnus = 0;
+
+	/* tbj mode */
+
+    if (cts2) {
+	  cpB = -26002;
+      if (stid==9) {
+	    ifreqsB[0] = 23;
+		ifreqsB[1] = 26;
+		ifreqsB[2] = 28;
+		ifreqsB[3] = 30;
+		ifreqsB[4] = 32;
+		ifreqsB[5] = 34;
+		ifreqsB[6] = 35;
+      } else if (stid==10) {
+		ifreqsB[0] = 2;
+		ifreqsB[1] = 4;
+		ifreqsB[2] = 5;
+		ifreqsB[3] = 6;
+		ifreqsB[4] = 7;
+		ifreqsB[5] = 8;
+		ifreqsB[6] = 10;
+      }
+     }
+
+	 /* normal scan */
+
+	 if (cts4) cpB = -26004;
+	
+	 /* single camp beam */
+
+	if (cts6) {
+	  cpB = -26006;
+      if (stid==9) ibeamsB[0] = SINGLE_CAMP_BEAM_PYK;
+      else ibeamsB[0] = SINGLE_CAMP_BEAM_HAN;
+
+	}
+
+	/* double camp beam */
+
+	if (cts8) {
+	  cpB = -26008;
+
+	  ibeamsB[0] = DOUBLE_CAMP_LOW;
+	  ibeamsB[1] = DOUBLE_CAMP_HIGH;
+	}
+  } else if ((cts3) || (cts5) || (cts7) || (cts9)) {
+    cpA = 153;
+	intsc = 3;
+	stereo_offset = 400;
+	scnsc = 60.0;
+    scnus = 0.0;
+
+	/* tbj */
+
+	if (cts3) {
+	  cpB = -26003;
+       
+	  if (stid==9) {
+	    ifreqsB[0] = 23;
+		ifreqsB[1] = 26;
+		ifreqsB[2] = 28;
+		ifreqsB[3] = 30;
+		ifreqsB[4] = 32;
+		ifreqsB[5] = 34;
+		ifreqsB[6] = 35;
+      } else if (stid==10) {
+		ifreqsB[0] = 2;
+		ifreqsB[1] = 4;
+		ifreqsB[2] = 5;
+		ifreqsB[3] = 6;
+		ifreqsB[4] = 7;
+		ifreqsB[5] = 8;
+		ifreqsB[6] = 10;
+      }
+	}
+
+	/* normal scan */
+
+	if (cts5) cpB = -26005;
+	
+
+	/* single camp beam */
+
+	if (cts7) {
+	  cpB = -26007;
+      if (stid==9) ibeamsB[0] = SINGLE_CAMP_BEAM_PYK;
+      else ibeamsB[0] = SINGLE_CAMP_BEAM_HAN;
+
+	}
+
+	/* double camp beam */
+
+	if (cts9) {
+	  cpB = -26009;
+
+	  ibeamsB[0] = DOUBLE_CAMP_LOW;
+	  ibeamsB[1] = DOUBLE_CAMP_HIGH;
+	}
+  } else
+    /* check for normal scan emulation */
+  if (ns) {
+    frangA		= FRANG_A;
+	rsepA		= RSEP_A;
+	low_beam_A	= LOW_BEAM_A;
+	high_beam_A	= HIGH_BEAM_A;
+
+	intsc = 7;
+    intus = 0;
+	scnsc = 120.0;
+    scnus = 0.0;
+	cpA = CPID_NS;  
+  } else
+    /* check for fast scan emulation */
+  if (fs) {
+    frangA		= FRANG_A;
+	rsepA		= RSEP_A;
+	low_beam_A	= LOW_BEAM_A;
+	high_beam_A	= HIGH_BEAM_A;
+
+	intsc = 3;
+    intus = 0;
+	scnsc = 60.0;
+    scnus = 0.0;
+	cpA = CPID_FS;
+  }
+
+  /* set cpid for channel A */
+
+  if (cpidA) {
+     cpA = cpidA;
+	 cpB = -1 * abs(cpidA) - 20000;
+  }
+
+  /* set cpid for channel B */
+
+  if (cpidB) cpB = cpidB;
+	
+  /* Calculate delay offsets
+     If stereo_offset is +ve A is later than B
+  */
+
+  if (stereo_offset > 0) {
+    delays[1] = 0;
+	delays[0] = stereo_offset / 10; /* remember stereo_offset is in usec */
+  } else {
+    delays[0] = 0;
+	delays[1] = (stereo_offset / 10) * (-1); /* stereo_offset is in usec */
+  }
+
+  mppulA = mppulB = 7;
+  mplgsA = mplgsB = 18;
+
+  txplA = (rsepA * 20) / 3;
+  txplB = (rsepB * 20) / 3;
+
+  /* just a dummy frequency */
+
+  tfreqA = 13500;
+  tfreqB = 14500; 
+
+  SiteSetupHardware();
+
+  /* remove invalid entries in the frequency band lists */
+
+  RemInvalidEntries(ifreqsA, ifreqsB);
+
+  /* determine the number of frequency bands */
+
+  FindNumBands(&numfreqbandsA, &numfreqbandsB, 
+               &day_nightA, &day_nightB, ifreqsA, ifreqsB, 1);
+
+  /* check beams */
+
+  if (low_beam_A  <  LOW_BEAM_A) low_beam_A  = LOW_BEAM_A;
+  if (high_beam_A > HIGH_BEAM_A) high_beam_A = HIGH_BEAM_A;
+
+  if (low_beam_B  <  LOW_BEAM_B) low_beam_B  = LOW_BEAM_B;
+  if (high_beam_B > HIGH_BEAM_B) high_beam_B = HIGH_BEAM_B;
+
+  /* end beams in the wrong order */
+
+  if (low_beam_A > high_beam_A) {
+    int beam = high_beam_A;
+    high_beam_A = low_beam_A;
+	low_beam_A  = beam;
+  }
+
+  if (low_beam_B > high_beam_B) {
+    int beam = high_beam_B;
+    high_beam_B = low_beam_B;
+	low_beam_B  = beam;
+  }
+
+  /* sort beam lists */
+
+  RemInvalidBeams(ibeamsA, ibeamsB);			
+  FindNumBeams(&numbeamsA, &numbeamsB, ibeamsA, ibeamsB, 1);
+
+  /*
+	the beam lists now contain:
+	1) the number of beams in the beam lists
+	2) if no beam list or camp beams were specified = 0 -> 15
+	3) if high and low beams were specified			= low_beam -> high_beam
+  */
+   
+  sprintf(progname,"stereoscan");
+
+  OpsFitACFStart();
+
+  OpsSetupTask(tasklist);
+  for (n=0;n<tnum;n++) {
+    RMsgSndReset(tlist[n]);
+    RMsgSndOpen(tlist[n],strlen(cmdlne),cmdlne);     
+  }
+
+  /* scan loop */
+
+  do {
+
+    if (SiteStartScan()==0) continue;
+
+    if (OpsReOpen(2,0,0) !=0) {
+      ErrLog(errlog,progname,"Opening new files.");
+      for (n=0;n<tnum;n++) {
+        RMsgSndClose(tlist[n]);
+        RMsgSndOpen(tlist[n],strlen(cmdlne),cmdlne);     
+      }
+    }
+
+    if (backward) scanA=scanB=-1;
+    else scanA=scanB=1; 
+
+    ErrLog(errlog,progname,"Starting scan.");
+
+
+    for (ibeamsA_index=0;ibeamsA_index<numbeamsA;ibeamsA_index++) {
+
+      bmnumA=ibeamsA[ibeamsA_index];
+      bmnumB=ibeamsB[ibeamsB_index];
+
+	  ifreqsAband = ifreqsA[ifreqsA_index];
+	  ifreqsBband = ifreqsB[ifreqsB_index];
+
+      TimeReadClock(&yr,&mo,&dy,&hr,&mt,&sc,&us);
+
+      if (day_nightA) { 
+        if (OpsDayNight()==1) {
+           stfrqA=usfreq[dfrqA];
+           frqrngA=ufreq_range[dfrqA];
+        } else {
+           stfrqA=usfreq[nfrqA];
+           frqrngA=ufreq_range[nfrqA];
+        } 
+      } else {
+        stfrqA=usfreq[ifreqsAband];
+        frqrngA=ufreq_range[ifreqsAband];
+      }
+
+      if (day_nightB) { 
+        if (OpsDayNight()==1) {
+           stfrqB=usfreq[dfrqB];
+           frqrngB=ufreq_range[dfrqB];
+        } else {
+           stfrqB=usfreq[nfrqB];
+           frqrngB=ufreq_range[nfrqB];
+        } 
+      } else {
+        stfrqB=usfreq[ifreqsBband];
+        frqrngB=ufreq_range[ifreqsBband];
+      }
+
+      SiteSetChannel(CHN_B);
+      SiteSetBeam(bmnumB);
+      SiteSetChannel(CHN_A);
+      SiteSetBeam(bmnumA);
+ 
+      SiteSetIntt(intsc,intus);
+ 
+      if (SiteFCLRS(stfrqA,stfrqA+frqrngA,stfrqB,
+                    stfrqB+frqrngB)==FREQ_LOCAL)
+        ErrLog(errlog,progname,"Frequency Synthesizer in local mode.");
+
+      if (tfreqA==-1) tfreqA=ftable->dfrq;
+      if (tfreqB==-1) tfreqB=ftable->dfrq;
+
+      sprintf(logtxt,"Channel A Transmitting on: %d (Noise=%g)",tfreqA,noiseA);
+      ErrLog(errlog,progname,logtxt);
+
+      sprintf(logtxt,"Channel B Transmitting on: %d (Noise=%g)",tfreqB,noiseB);
+      ErrLog(errlog,progname,logtxt);
+
+      SiteSetChannel(CHN_A);
+      SiteSetFreq(tfreqA);
+      SiteSetChannel(CHN_B);
+      SiteSetFreq(tfreqB);
+
+	  sprintf(logtxt,"Integrating:%2d,%2d intt:%d (%02d:%02d:%02d) %5d (%02d)  %5d (%02d) - %s  %d\n",
+		      bmnumA, bmnumB, intsc, hr, mt, 
+              sc, tfreqA, ifreqsAband, tfreqB, ifreqsBband, 
+              OpsDayNight() ? "day" : "night", abs(tfreqA - tfreqB));
+
+      ErrLog(errlog,progname,logtxt);
+
+      u_read_uconts();
+
+      txplA = (rsepA * 20) / 3;
+      txplB = (rsepB * 20) / 3;
+
+      tsgidA=SiteTimeSeqS(0,ptab);
+      tsgidB=SiteTimeSeqS(1,ptab);
+
+      SiteIntegrateS(lags,lags);   
+   
+
+      if (naveA<0) {
+        sprintf(logtxt,"Integration A failed:%d",naveA);
+        ErrLog(errlog,progname,logtxt); 
+        continue;
+      }
+      if (naveB<0) {
+        sprintf(logtxt,"Integration B failed:%d",naveB);
+        ErrLog(errlog,progname,logtxt); 
+        continue;
+      }
+
+      sprintf(logtxt,"Number of sequences: %d %d",naveA,naveB);
+      ErrLog(errlog,progname,logtxt);
+
+      OpsBuildRawS(0,&prmA,&rawA,ptab,lags);
+      OpsBuildRawS(1,&prmB,&rawB,ptab,lags);
+
+      FitACF(&prmA,&rawA,&fblk,&fitA);
+      FitACF(&prmB,&rawB,&fblk,&fitB);
+
+      ErrLog(errlog,progname,"Sending messages."); 
+  
+
+      msg.num=0;
+      msg.tsize=0;
+
+      RMsgSndAdd(&msg,sizeof(struct RadarParm),(unsigned char *) &prmA,
+		PRM_TYPE,0); 
+      RMsgSndAdd(&msg,sizeof(struct RawData),(unsigned char *) &rawA,
+		RAW_TYPE,0);    
+
+      RMsgSndAdd(&msg,sizeof(struct FitData),(unsigned char *) &fitA,
+		FIT_TYPE,0);
+
+      RMsgSndAdd(&msg,strlen(progname)+1,progname,
+		NME_TYPE,0);   
+
+      RMsgSndAdd(&msg,sizeof(struct RadarParm),(unsigned char *) &prmB,
+		PRM_TYPE,1); 
+      RMsgSndAdd(&msg,sizeof(struct RawData),(unsigned char *) &rawB,
+		RAW_TYPE,1);    
+
+      RMsgSndAdd(&msg,sizeof(struct FitData),(unsigned char *) &fitB,
+		FIT_TYPE,1);
+
+   
+      RMsgSndAdd(&msg,strlen(progname)+1,progname,
+		NME_TYPE,1);   
+ 
+
+      for (n=0;n<tnum;n++) RMsgSndSend(tlist[n],&msg); 
+  
+      ErrLog(errlog,progname,"Polling for exit."); 
+ 
+      exitpoll=RadarShell(sid,&rstable);
+
+	  /* check the bands and beams here, after radar shell */
+
+	  RemInvalidBeams(ibeamsA, ibeamsB);			
+	  FindNumBeams(&numbeamsA, &numbeamsB, ibeamsA, ibeamsB, 0);
+
+	  RemInvalidEntries(ifreqsA, ifreqsB);
+	  FindNumBands(&numfreqbandsA, &numfreqbandsB, &day_nightA, &day_nightB, ifreqsA, ifreqsB, 0);
+
+	  if (ifreqsA_index >= numfreqbandsA) ifreqsA_index = 0;
+	  if (ifreqsB_index >= numfreqbandsB) ifreqsB_index = 0;
+  
+	  /* Calculate delay offsets if stereo offset has been changed
+         If stereo_offset is +ve A is later than B
+       */
+
+	  if (stereo_offset > 0) {
+	    delays[1] = 0;
+		delays[0] = stereo_offset / 10; /* stereo_offset is in usec */
+ 	  } else {
+		delays[0] = 0;
+		delays[1] = (stereo_offset / 10) * (-1); /* stereo_offset is in usec */
+	  }
+
+	  if (exitpoll !=0) break;
+
+	  scanA = 0;
+	  scanB = 0;
+
+	  /* change beam number index */
+
+	  ibeamsB_index++;
+
+	  if (ibeamsB_index >= numbeamsB) ibeamsB_index = 0;
+
+	  /* change band at the end of channel B scan */
+
+	  if (ibeamsB_index == 0) {
+	    if (numfreqbandsB != 0) {
+		  ifreqsB_index++;
+          if (ifreqsB_index >= numfreqbandsB) ifreqsB_index = 0;
+		}
+	  }
+    } 
+    
+	/* increment individual frequency band index. Doesn't matter whether
+	   individual frequency bands are being used for this channel or not.
+     */
+
+    if (numfreqbandsA != 0) {
+      ifreqsA_index++;
+      if (ifreqsA_index >= numfreqbandsA) ifreqsA_index = 0;
+    }
+
+    ErrLog(errlog,progname,"Waiting for scan boundary."); 
+    if ((scnsc !=0) || (scnus !=0)) {
+      if (exitpoll==0) OpsWaitBoundary(scnsc,scnus);
+    }
+  } while (exitpoll==0);
+  SiteEnd();
+  for (n=0;n<tnum;n++) RMsgSndClose(tlist[n]);
+  ErrLog(errlog,progname,"Ending program.");
+  RShellTerminate(sid);
+  return 0;   
+} 
+ 
+
+/***************************************************************************/
+
+/* Sets up the licenced frequency bands for Iceland & finland */
+
+void u_init_freq_bands() {
+
+/* start freq of each band */
+
+   /* Finland */
+
+   usfreq[0] = 8305;
+   usfreq[1] = 8965;
+   usfreq[2] = 9900;
+   usfreq[3] = 11075;
+   usfreq[4] = 11550;
+   usfreq[5] = 12370;
+   usfreq[6] = 13200;
+   usfreq[7] = 15010;
+   usfreq[8] = 16210;
+   usfreq[9] = 16555;
+   usfreq[10] = 17970;
+   usfreq[11] = 18850;
+   usfreq[12] = 19415;
+   usfreq[13] = 19705;
+   usfreq[14] = 19800;
+
+   /* Iceland */
+
+   usfreq[20] = 8000;
+   usfreq[21] = 8430;
+   usfreq[22] = 8985;
+   usfreq[23] = 10155;
+   usfreq[24] = 10655;
+   usfreq[25] = 11290;
+   usfreq[26] = 11475;
+   usfreq[27] = 12105;
+   usfreq[28] = 12305;
+   usfreq[29] = 12590;
+   usfreq[30] = 13360;
+   usfreq[31] = 13875;
+   usfreq[32] = 14400;
+   usfreq[33] = 15805;
+   usfreq[34] = 16500;
+   usfreq[35] = 16820;
+   usfreq[36] = 18175;
+   usfreq[37] = 18835;
+   usfreq[38] = 19910;
+   usfreq[39] = 10155;
+
+   /* width of each band */
+
+   /* Finland */
+
+   ufreq_range[0] = 30;
+   ufreq_range[1] = 75;
+   ufreq_range[2] = 85;
+   ufreq_range[3] = 200;
+   ufreq_range[4] = 50;
+   ufreq_range[5] = 45;
+   ufreq_range[6] = 60;
+   ufreq_range[7] = 70;
+   ufreq_range[8] = 150;
+   ufreq_range[9] = 60;
+   ufreq_range[10] = 80;
+   ufreq_range[11] = 15;
+   ufreq_range[12] = 265;
+   ufreq_range[13] = 50;
+   ufreq_range[14] = 190; 
+
+   /* Iceland */
+
+   ufreq_range[20] = 195;
+   ufreq_range[21] = 420;
+   ufreq_range[22] = 410;
+   ufreq_range[23] = 500;
+   ufreq_range[24] = 520;
+   ufreq_range[25] = 160;
+   ufreq_range[26] = 120;
+   ufreq_range[27] = 130;
+   ufreq_range[28] = 205;
+   ufreq_range[29] = 690;
+   ufreq_range[30] = 205;
+   ufreq_range[31] = 120;
+   ufreq_range[32] = 615;
+   ufreq_range[33] = 560;
+   ufreq_range[34] = 185;
+   ufreq_range[35] = 655;
+   ufreq_range[36] = 595;
+   ufreq_range[37] = 50;
+   ufreq_range[38] = 90;
+   ufreq_range[39] = 1020;
+}
+
+/* Sends a proxy message to the microcontroller monitoring 
+   task every beam.
+*/
+
+void u_read_uconts() {
+  if (uucont_proxy != 0) Trigger(uucont_proxy);
+}
+
+
+
+/* remove invalid entries in the frequency band lists */
+
+void RemInvalidEntries(int ifreqsA[NUMBANDS], int ifreqsB[NUMBANDS]) {
+  int i, j;
+
+  for (i = NUMBANDS - 1; i > 0; i--) {
+
+	/* if the preceding element is -1 then move all the following
+	   bands down
+     */
+
+	if ((ifreqsA[i] != -1) && (ifreqsA[i - 1] == -1)) {
+	  for (j = i; j < NUMBANDS; j++) {
+	    ifreqsA[j - 1] = ifreqsA[j];
+		ifreqsA[j] = -1;
+	  }
+	}
+
+	if ((ifreqsB[i] != -1) && (ifreqsB[i - 1] == -1)) {
+	  for (j = i; j < NUMBANDS; j++) {
+	    ifreqsB[j - 1] = ifreqsB[j];
+		ifreqsB[j] = -1;
+	  }
+	}
+  }
+}
+
+/* determine the number of frequency bands */
+
+void FindNumBands(int *numfreqbandsA, int *numfreqbandsB, 
+                  int *day_nightA, int *day_nightB, 
+                  int ifreqsA[NUMBANDS], int ifreqsB[NUMBANDS], 
+                  int print) {
+  int i;
+  char logtxt[256];
+
+  *numfreqbandsA = 0;
+  *numfreqbandsB = 0;
+
+  for (i = 0; i < NUMBANDS; i++) {
+    if (ifreqsA[i] != -1) (*numfreqbandsA)++;
+	if (ifreqsB[i] != -1) (*numfreqbandsB)++;
+  }
+
+  /* check to see if day/night frequencies are to be used */
+
+  if (*numfreqbandsA != 0) *day_nightA = 0;
+  else *day_nightA = 1;
+
+  if (*numfreqbandsB != 0) *day_nightB = 0;
+  else *day_nightB = 1;
+
+  if (print) {
+    sprintf(logtxt, "Channel A: %d  Channel B: %d", *numfreqbandsA, 
+            *numfreqbandsB);
+	ErrLog(errlog, progname, logtxt);
+  }
+
+  /* print frequency bands for each channel */
+
+  if ((*numfreqbandsA > 0) && print) {
+    ErrLog(errlog,progname,"Frequency bands for channel A: ");
+
+    for (i = 0; i < *numfreqbandsA; i++) {
+	  sprintf(logtxt, "%1d ", ifreqsA[i]);
+	  ErrLog(errlog,progname,logtxt);
+	}
+  }
+
+  if ((*numfreqbandsB > 0) && print) {
+    ErrLog(errlog,progname,"Frequency bands for channel B: ");
+
+	for (i = 0; i < *numfreqbandsB; i++) {
+	  sprintf(logtxt, "%1d ", ifreqsB[i]);
+	  ErrLog(errlog,progname,logtxt);
+	}
+  }
+}
+
+/* remove invalid entries in the beam lists */
+
+void RemInvalidBeams(int ibeamsA[NUMBEAMS], int ibeamsB[NUMBEAMS]) {
+  int i, j;
+
+  for (i = NUMBEAMS - 1; i > 0; i--) {
+    if (ibeamsA[i] <  0) ibeamsA[i] = -1;
+	if (ibeamsA[i] > 15) ibeamsA[i] = -1;
+
+	if (ibeamsB[i] <  0) ibeamsB[i] = -1;
+	if (ibeamsB[i] > 15) ibeamsB[i] = -1;
+  }
+
+  for (i = NUMBEAMS - 1; i > 0; i--) {
+
+	/* if the preceding element is -1 then move all the 
+       following beams down
+     */
+
+	if ((ibeamsA[i - 1] == -1) && (ibeamsA[i] != -1)) {
+	  for (j = i; j < NUMBEAMS; j++) {
+	    ibeamsA[j - 1] = ibeamsA[j];
+		ibeamsA[j] = -1;
+	  }
+	}
+
+	if ((ibeamsB[i - 1] == -1) && (ibeamsB[i] != -1)) {
+	  for (j = i; j < NUMBEAMS; j++) {
+	    ibeamsB[j - 1] = ibeamsB[j];
+		ibeamsB[j] = -1;
+	  }
+	}
+  }
+}
+
+/* determine the number of beams */
+
+void FindNumBeams(int *numbeamsA, int *numbeamsB, 
+                  int ibeamsA[NUMBEAMS], int ibeamsB[NUMBEAMS], 
+                  int print) {
+  int i;
+  char logtxt[256];
+
+  *numbeamsA = 0;
+  *numbeamsB = 0;
+
+  /* count channel A beams */
+
+  for (i = 0; i < NUMBEAMS; i++) {
+    if (ibeamsA[i] != -1) (*numbeamsA)++;
+	else break;
+  }
+
+  /* count channel B beams */
+
+  for (i = 0; i < NUMBEAMS; i++) {
+    if (ibeamsB[i] != -1) (*numbeamsB)++;
+	else break;
+  }
+
+  if (print) {
+    sprintf(logtxt, "Beams A: %d  Beams B: %d", *numbeamsA, *numbeamsB);
+	ErrLog(errlog, progname, logtxt);
+
+	/* print frequency bands for each channel */
+
+	if (*numbeamsA > 0) {
+	  ErrLog(errlog,progname,"Beams for channel A: ");
+
+	  for (i = 0; i < *numbeamsA; i++) {
+	    sprintf(logtxt, "%1d ", ibeamsA[i]);
+	    ErrLog(errlog,progname,logtxt);
+	  }
+	}
+
+	if (*numbeamsB > 0) {
+	  ErrLog(errlog,progname,"Beams for channel B: ");
+       for (i = 0; i < *numbeamsB; i++) {
+	     sprintf(logtxt, "%1d ", ibeamsB[i]);
+		 ErrLog(errlog,progname,logtxt);
+	   }
+	}
+  }
+
+  /* if no beams have been specified fill the arrays with normal sequence
+     between low_beam and high beam.  
+   */
+  
+  if (*numbeamsA == 0) {
+    if (backward) {
+      for (i = 0; i < (high_beam_A - low_beam_A + 1); i++) {
+        ibeamsA[i] = high_beam_A - i;
+        (*numbeamsA)++;
+ 	  }
+    } else {
+ 	  for (i = 0; i < (high_beam_A - low_beam_A + 1); i++) {
+	    ibeamsA[i] = low_beam_A + i;
+        (*numbeamsA)++;
+	  }
+    }
+  }
+
+  if (*numbeamsB == 0) {
+
+	if (backward) {
+      for (i = 0; i < (high_beam_B - low_beam_B + 1); i++) {
+  	    ibeamsB[i] = high_beam_B - i;
+        (*numbeamsB)++;
+	  }
+    } else {
+  	  for (i = 0; i < (high_beam_B - low_beam_B + 1); i++) {
+        ibeamsB[i] = low_beam_B + i;
+        (*numbeamsB)++;
+	  }
+    }
+  }
+}
+
+
+
+

--- a/qnx4/sd_leicester/pyk/stereoscan.1.04/version.info
+++ b/qnx4/sd_leicester/pyk/stereoscan.1.04/version.info
@@ -1,0 +1,15 @@
+# $Log: version.info,v $
+# Revision 1.4  2007/08/09 14:10:26  code
+# Added the ability to pass command line options as a file.
+#
+# Revision 1.3  2007/08/08 16:56:07  code
+# Fixed bug in using hex notation for stid.
+#
+# Revision 1.2  2006/07/12 15:51:55  code
+# Added call to set up command line and limited data written to rawacf and fitacf.
+#
+# Revision 1.1  2006/03/30 11:28:25  barnes
+# Initial revision
+#
+#
+stereoscan.c 1.04

--- a/qnx6/interleavesound.1.0/interleavesound_cv.c
+++ b/qnx6/interleavesound.1.0/interleavesound_cv.c
@@ -109,7 +109,6 @@ int main(int argc,char *argv[]) {
   char tempLog[40];
 
   int exitpoll=0;
-  int scannowait=0;
 
   int scnsc=60;
   int scnus=0;
@@ -121,7 +120,7 @@ int main(int argc,char *argv[]) {
   int status=0;
   int fixfrq=0;
 
-  int def_nrang=100;
+  int def_nrang=0;
 
   /* new variables for dynamically creating beam sequences */
   int *bms;           /* scanning beams                                     */
@@ -177,7 +176,7 @@ int main(int argc,char *argv[]) {
   mplgs  = 23;
   mpinc  = 1500;
   dmpinc = 1500;
-  nrang  = def_nrang;
+  nrang  = 100;
   rsep   = 45;
   txpl   = 300;     /* note: recomputed below */
   dfrq   = 10200;
@@ -250,9 +249,6 @@ int main(int argc,char *argv[]) {
     fprintf(stderr,"Sounder File: %s not found\n",snd_filename);
   }
 
-  /* end of main Dartmouth mods */
-  /* not sure if -nrang commandline option works */
-
   if ((errlog.sock=TCPIPMsgOpen(errlog.host,errlog.port))==-1) {
     fprintf(stderr,"Error connecting to error log.\n");
   }
@@ -262,14 +258,9 @@ int main(int argc,char *argv[]) {
 
   for (n=0;n<tnum;n++) task[n].port+=baseport;
 
-  /* rst/usr/codebase/superdarn/src.lib/os/ops.1.10/src/setup.c */
   OpsStart(ststr);
 
-  /* rst/usr/codebase/superdarn/src.lib/os/site.1.3/src/build.c */
-  /* note that stid is a global variable set in the previous function...
-      rst/usr/codebase/superdarn/src.lib/os/ops.1.10/src/global.c */
   status=SiteBuild(stid);
-
   if (status==-1) {
     fprintf(stderr,"Could not identify station.\n");
     exit(1);
@@ -292,7 +283,6 @@ int main(int argc,char *argv[]) {
 
   strncpy(combf,progid,80);
 
-  /* rst/usr/codebase/superdarn/src.lib/os/ops.1.10/src */
   OpsSetupCommand(argc,argv);
   OpsSetupShell();
 
@@ -443,7 +433,6 @@ int main(int argc,char *argv[]) {
 
     } while (1);
 
-    ErrLog(errlog.sock,progname,"Waiting for scan boundary.");
 
     if (exitpoll==0) {
       /* In here comes the sounder code */
@@ -453,15 +442,20 @@ int main(int argc,char *argv[]) {
       /* set the xcf variable to do cross-correlations (AOA) */
       xcf = 1;
 
+      /* set the sounding mode integration time and number of ranges */
+      intsc = snd_intt_sc;
+      intus = snd_intt_us;
+      nrang = snd_nrang;
+
+      /* make a new timing sequence for the sounding */
+      tsgid = SiteTimeSeq(ptab);
+
       /* we have time until the end of the minute to do sounding */
       /* minus a safety factor given in time_needed */
       TimeReadClock(&yr,&mo,&dy,&hr,&mt,&sc,&us);
       snd_time = 60.0 - (sc + us*1e-6);
 
       while (snd_time-snd_intt > time_needed) {
-        intsc = snd_intt_sc;
-        intus = snd_intt_us;
-        nrang = snd_nrang;
 
         /* set the beam */
         bmnum = snd_bms[snd_bm_cnt] + odd_beams;
@@ -470,19 +464,19 @@ int main(int argc,char *argv[]) {
         snd_freq = snd_freqs[snd_freq_cnt];
 
         /* the scanning code is here */
-        tsgid = SiteTimeSeq(ptab);
         sprintf(logtxt,"Integrating SND beam:%d intt:%ds.%dus (%d:%d:%d:%d)",bmnum,intsc,intus,hr,mt,sc,us);
         ErrLog(errlog.sock,progname,logtxt);
         ErrLog(errlog.sock,progname,"Setting SND beam.");
         SiteStartIntt(intsc,intus);
+
         ErrLog(errlog.sock, progname, "Doing SND clear frequency search.");
         sprintf(logtxt, "FRQ: %d %d", snd_freq, snd_frqrng);
         ErrLog(errlog.sock,progname, logtxt);
         tfreq = SiteFCLR(snd_freq, snd_freq + snd_frqrng);
-/*
- *           sprintf(logtxt,"Transmitting SND on: %d (Noise=%g)",tfreq,noise);
- *                     ErrLog(errlog.sock, progname, logtxt);
- *                     */
+
+        sprintf(logtxt,"Transmitting SND on: %d (Noise=%g)",tfreq,noise);
+        ErrLog(errlog.sock, progname, logtxt);
+
         nave = SiteIntegrate(lags);
         if (nave < 0) {
           sprintf(logtxt, "SND integration error: %d", nave);
@@ -563,10 +557,13 @@ int main(int argc,char *argv[]) {
       }
 
       /* now wait for the next interleavescan */
+      ErrLog(errlog.sock,progname,"Waiting for scan boundary.");
+
       intsc = fast_intt_sc;
       intus = fast_intt_us;
       nrang = def_nrang;
-      if (scannowait==0) SiteEndScan(scnsc,scnus,5000);
+
+      SiteEndScan(scnsc,scnus,5000);
     }
 
   } while (exitpoll==0);
@@ -651,6 +648,8 @@ void write_snd_record(char *progname, struct RadarParm *prm, struct FitData *fit
   status = SndFwrite(out, prm, fit);
   if (status == -1) {
     ErrLog(errlog.sock,progname,"Error writing sounding record.");
+  } else {
+    ErrLog(errlog.sock,progname,"Sounding record successfully written.");
   }
 
   fclose(out);

--- a/qnx6/interleavesound.1.0/interleavesound_cv.c
+++ b/qnx6/interleavesound.1.0/interleavesound_cv.c
@@ -108,8 +108,6 @@ int main(int argc,char *argv[]) {
   char logtxt[1024]="";
   char tempLog[40];
 
-  int exitpoll=0;
-
   int scnsc=60;
   int scnus=0;
 
@@ -425,7 +423,6 @@ int main(int argc,char *argv[]) {
 
       RadarShell(shell.sock,&rstable);
 
-      if (exitpoll !=0 ) break;
       scan = 0;
       if (skip == (nintgs-1)) break;
       skip++;
@@ -434,139 +431,136 @@ int main(int argc,char *argv[]) {
     } while (1);
 
 
-    if (exitpoll==0) {
-      /* In here comes the sounder code */
-      /* set the "sounder mode" scan variable */
-      scan = -2;
+    /* In here comes the sounder code */
+    /* set the "sounder mode" scan variable */
+    scan = -2;
 
-      /* set the xcf variable to do cross-correlations (AOA) */
-      xcf = 1;
+    /* set the xcf variable to do cross-correlations (AOA) */
+    xcf = 1;
 
-      /* set the sounding mode integration time and number of ranges */
-      intsc = snd_intt_sc;
-      intus = snd_intt_us;
-      nrang = snd_nrang;
+    /* set the sounding mode integration time and number of ranges */
+    intsc = snd_intt_sc;
+    intus = snd_intt_us;
+    nrang = snd_nrang;
 
-      /* make a new timing sequence for the sounding */
-      tsgid = SiteTimeSeq(ptab);
+    /* make a new timing sequence for the sounding */
+    tsgid = SiteTimeSeq(ptab);
 
-      /* we have time until the end of the minute to do sounding */
-      /* minus a safety factor given in time_needed */
-      TimeReadClock(&yr,&mo,&dy,&hr,&mt,&sc,&us);
-      snd_time = 60.0 - (sc + us*1e-6);
+    /* we have time until the end of the minute to do sounding */
+    /* minus a safety factor given in time_needed */
+    TimeReadClock(&yr,&mo,&dy,&hr,&mt,&sc,&us);
+    snd_time = 60.0 - (sc + us*1e-6);
 
-      while (snd_time-snd_intt > time_needed) {
+    while (snd_time-snd_intt > time_needed) {
 
-        /* set the beam */
-        bmnum = snd_bms[snd_bm_cnt] + odd_beams;
+      /* set the beam */
+      bmnum = snd_bms[snd_bm_cnt] + odd_beams;
 
-        /* snd_freq will be an array of frequencies to step through */
-        snd_freq = snd_freqs[snd_freq_cnt];
+      /* snd_freq will be an array of frequencies to step through */
+      snd_freq = snd_freqs[snd_freq_cnt];
 
-        /* the scanning code is here */
-        sprintf(logtxt,"Integrating SND beam:%d intt:%ds.%dus (%d:%d:%d:%d)",bmnum,intsc,intus,hr,mt,sc,us);
-        ErrLog(errlog.sock,progname,logtxt);
-        ErrLog(errlog.sock,progname,"Setting SND beam.");
-        SiteStartIntt(intsc,intus);
+      /* the scanning code is here */
+      sprintf(logtxt,"Integrating SND beam:%d intt:%ds.%dus (%d:%d:%d:%d)",bmnum,intsc,intus,hr,mt,sc,us);
+      ErrLog(errlog.sock,progname,logtxt);
+      ErrLog(errlog.sock,progname,"Setting SND beam.");
+      SiteStartIntt(intsc,intus);
 
-        ErrLog(errlog.sock, progname, "Doing SND clear frequency search.");
-        sprintf(logtxt, "FRQ: %d %d", snd_freq, snd_frqrng);
+      ErrLog(errlog.sock, progname, "Doing SND clear frequency search.");
+      sprintf(logtxt, "FRQ: %d %d", snd_freq, snd_frqrng);
+      ErrLog(errlog.sock,progname, logtxt);
+      tfreq = SiteFCLR(snd_freq, snd_freq + snd_frqrng);
+
+      sprintf(logtxt,"Transmitting SND on: %d (Noise=%g)",tfreq,noise);
+      ErrLog(errlog.sock, progname, logtxt);
+
+      nave = SiteIntegrate(lags);
+      if (nave < 0) {
+        sprintf(logtxt, "SND integration error: %d", nave);
         ErrLog(errlog.sock,progname, logtxt);
-        tfreq = SiteFCLR(snd_freq, snd_freq + snd_frqrng);
+        continue;
+      }
+      sprintf(logtxt,"Number of SND sequences: %d",nave);
+      ErrLog(errlog.sock,progname,logtxt);
 
-        sprintf(logtxt,"Transmitting SND on: %d (Noise=%g)",tfreq,noise);
-        ErrLog(errlog.sock, progname, logtxt);
+      OpsBuildPrm(prm,ptab,lags);
+      OpsBuildIQ(iq,&badtr);
+      OpsBuildRaw(raw);
+      FitACF(prm,raw,fblk,fit);
 
-        nave = SiteIntegrate(lags);
-        if (nave < 0) {
-          sprintf(logtxt, "SND integration error: %d", nave);
-          ErrLog(errlog.sock,progname, logtxt);
-          continue;
-        }
-        sprintf(logtxt,"Number of SND sequences: %d",nave);
-        ErrLog(errlog.sock,progname,logtxt);
+      ErrLog(errlog.sock, progname, "Sending SND messages.");
+      msg.num = 0;
+      msg.tsize = 0;
 
-        OpsBuildPrm(prm,ptab,lags);
-        OpsBuildIQ(iq,&badtr);
-        OpsBuildRaw(raw);
-        FitACF(prm,raw,fblk,fit);
+      tmpbuf=RadarParmFlatten(prm,&tmpsze);
+      RMsgSndAdd(&msg,tmpsze,tmpbuf,PRM_TYPE,0);
 
-        ErrLog(errlog.sock, progname, "Sending SND messages.");
-        msg.num = 0;
-        msg.tsize = 0;
+      tmpbuf=IQFlatten(iq,prm->nave,&tmpsze);
+      RMsgSndAdd(&msg,tmpsze,tmpbuf,IQ_TYPE,0);
 
-        tmpbuf=RadarParmFlatten(prm,&tmpsze);
-        RMsgSndAdd(&msg,tmpsze,tmpbuf,PRM_TYPE,0);
+      RMsgSndAdd(&msg,sizeof(unsigned int)*2*iq->tbadtr,
+             (unsigned char *) badtr,BADTR_TYPE,0);
 
-        tmpbuf=IQFlatten(iq,prm->nave,&tmpsze);
-        RMsgSndAdd(&msg,tmpsze,tmpbuf,IQ_TYPE,0);
+      RMsgSndAdd(&msg,strlen(sharedmemory)+1,
+             (unsigned char *) sharedmemory,IQS_TYPE,0);
 
-        RMsgSndAdd(&msg,sizeof(unsigned int)*2*iq->tbadtr,
-               (unsigned char *) badtr,BADTR_TYPE,0);
+      tmpbuf=RawFlatten(raw,prm->nrang,prm->mplgs,&tmpsze);
+      RMsgSndAdd(&msg,tmpsze,tmpbuf,RAW_TYPE,0);
 
-        RMsgSndAdd(&msg,strlen(sharedmemory)+1,
-               (unsigned char *) sharedmemory,IQS_TYPE,0);
+      tmpbuf=FitFlatten(fit,prm->nrang,&tmpsze);
+      RMsgSndAdd(&msg,tmpsze,tmpbuf,FIT_TYPE,0);
 
-        tmpbuf=RawFlatten(raw,prm->nrang,prm->mplgs,&tmpsze);
-        RMsgSndAdd(&msg,tmpsze,tmpbuf,RAW_TYPE,0);
+      RMsgSndAdd(&msg,strlen(progname)+1,(unsigned char *) progname,NME_TYPE,0);
 
-        tmpbuf=FitFlatten(fit,prm->nrang,&tmpsze);
-        RMsgSndAdd(&msg,tmpsze,tmpbuf,FIT_TYPE,0);
-
-        RMsgSndAdd(&msg,strlen(progname)+1,(unsigned char *) progname,NME_TYPE,0);
-
-        RMsgSndSend(task[RT_TASK].sock,&msg);
-        for (n=0;n<msg.num;n++) {
-          if (msg.data[n].type==PRM_TYPE) free(msg.ptr[n]);
-          if (msg.data[n].type==IQ_TYPE) free(msg.ptr[n]);
-          if (msg.data[n].type==RAW_TYPE) free(msg.ptr[n]);
-          if (msg.data[n].type==FIT_TYPE) free(msg.ptr[n]);
-        }
-
-        sprintf(logtxt, "SBC: %d  SFC: %d", snd_bm_cnt, snd_freq_cnt);
-        ErrLog(errlog.sock, progname, logtxt);
-
-        /* set the scan variable for the sounding mode data file only */
-        if ((bmnum == snd_bms[0]) && (snd_freq == snd_freqs[0])) {
-          prm->scan = 1;
-        } else {
-          prm->scan = 0;
-        }
-
-        /* save the sounding mode data */
-        write_snd_record(progname, prm, fit);
-
-        ErrLog(errlog.sock, progname, "Polling SND for exit.\n");
-        if (exitpoll !=0) break;
-
-        /* check for the end of a beam loop */
-        snd_freq_cnt++;
-        if (snd_freq_cnt >= snd_freqs_tot) {
-          /* reset the freq counter and increment the beam counter */
-          snd_freq_cnt = 0;
-          snd_bm_cnt++;
-          if (snd_bm_cnt >= snd_bms_tot) {
-            snd_bm_cnt = 0;
-            odd_beams = !odd_beams;
-          }
-        }
-
-        /* see if we have enough time for another go round */
-        TimeReadClock(&yr, &mo, &dy, &hr, &mt, &sc, &us);
-        snd_time = 60.0 - (sc + us*1e-6);
+      RMsgSndSend(task[RT_TASK].sock,&msg);
+      for (n=0;n<msg.num;n++) {
+        if (msg.data[n].type==PRM_TYPE) free(msg.ptr[n]);
+        if (msg.data[n].type==IQ_TYPE) free(msg.ptr[n]);
+        if (msg.data[n].type==RAW_TYPE) free(msg.ptr[n]);
+        if (msg.data[n].type==FIT_TYPE) free(msg.ptr[n]);
       }
 
-      /* now wait for the next interleavescan */
-      ErrLog(errlog.sock,progname,"Waiting for scan boundary.");
+      sprintf(logtxt, "SBC: %d  SFC: %d", snd_bm_cnt, snd_freq_cnt);
+      ErrLog(errlog.sock, progname, logtxt);
 
-      intsc = fast_intt_sc;
-      intus = fast_intt_us;
-      nrang = def_nrang;
+      /* set the scan variable for the sounding mode data file only */
+      if ((bmnum == snd_bms[0]) && (snd_freq == snd_freqs[0])) {
+        prm->scan = 1;
+      } else {
+        prm->scan = 0;
+      }
 
-      SiteEndScan(scnsc,scnus,5000);
+      /* save the sounding mode data */
+      write_snd_record(progname, prm, fit);
+
+      ErrLog(errlog.sock, progname, "Polling SND for exit.\n");
+
+      /* check for the end of a beam loop */
+      snd_freq_cnt++;
+      if (snd_freq_cnt >= snd_freqs_tot) {
+        /* reset the freq counter and increment the beam counter */
+        snd_freq_cnt = 0;
+        snd_bm_cnt++;
+        if (snd_bm_cnt >= snd_bms_tot) {
+          snd_bm_cnt = 0;
+          odd_beams = !odd_beams;
+        }
+      }
+
+      /* see if we have enough time for another go round */
+      TimeReadClock(&yr, &mo, &dy, &hr, &mt, &sc, &us);
+      snd_time = 60.0 - (sc + us*1e-6);
     }
 
-  } while (exitpoll==0);
+    /* now wait for the next interleavescan */
+    ErrLog(errlog.sock,progname,"Waiting for scan boundary.");
+
+    intsc = fast_intt_sc;
+    intus = fast_intt_us;
+    nrang = def_nrang;
+
+    SiteEndScan(scnsc,scnus,5000);
+
+  } while (1);
 
   for (n=0;n<tnum;n++) RMsgSndClose(task[n].sock);
 

--- a/qnx6/interleavesound.1.0/interleavesound_cv.c
+++ b/qnx6/interleavesound.1.0/interleavesound_cv.c
@@ -346,7 +346,7 @@ int main(int argc,char *argv[]) {
       } else xcf=0;
     } else xcf=0;
 
-    skip = OpsFindSkip(scnsc,scnus);
+    skip = OpsFindSkip(scnsc,scnus,intsc,intus,0);
 
     bmnum = bms[skip];      /* no longer need forward and backward arrays... */
 
@@ -559,7 +559,7 @@ int main(int argc,char *argv[]) {
       /* now wait for the next interleavescan */
       intsc = fast_intt_sc;
       intus = fast_intt_us;
-      if (scannowait==0) SiteEndScan(scnsc,scnus);
+      if (scannowait==0) SiteEndScan(scnsc,scnus,5000);
     }
 
   } while (exitpoll==0);

--- a/qnx6/interleavesound.1.0/interleavesound_cv.c
+++ b/qnx6/interleavesound.1.0/interleavesound_cv.c
@@ -154,7 +154,7 @@ int main(int argc,char *argv[]) {
   int snd_freq;
   int snd_frqrng=100;
   int fast_intt_sc=2;
-  int fast_intt_us=500000;
+  int fast_intt_us=400000;
   int snd_intt_sc=1;
   int snd_intt_us=500000;
   float snd_time, snd_intt, time_needed=1.25;

--- a/qnx6/interleavesound.1.0/interleavesound_cv.c
+++ b/qnx6/interleavesound.1.0/interleavesound_cv.c
@@ -523,7 +523,7 @@ int main(int argc,char *argv[]) {
           if (msg.data[n].type==FIT_TYPE) free(msg.ptr[n]);
         }
 
-        sprintf(logtxt, "SBC: %d  SFC: %d\n", snd_bm_cnt, snd_freq_cnt);
+        sprintf(logtxt, "SBC: %d  SFC: %d", snd_bm_cnt, snd_freq_cnt);
         ErrLog(errlog.sock, progname, logtxt);
 
         /* set the scan variable for the sounding mode data file only */
@@ -536,7 +536,7 @@ int main(int argc,char *argv[]) {
         /* save the sounding mode data */
         write_snd_record(progname, prm, fit);
 
-        ErrLog(errlog.sock, progname, "Polling SND for exit.");
+        ErrLog(errlog.sock, progname, "Polling SND for exit.\n");
         if (exitpoll !=0) break;
 
         /* check for the end of a beam loop */

--- a/qnx6/interleavesound.1.0/interleavesound_cv.c
+++ b/qnx6/interleavesound.1.0/interleavesound_cv.c
@@ -121,6 +121,8 @@ int main(int argc,char *argv[]) {
   int status=0;
   int fixfrq=0;
 
+  int def_nrang=100;
+
   /* new variables for dynamically creating beam sequences */
   int *bms;           /* scanning beams                                     */
   int intgt[20];      /* start times of each integration period             */
@@ -153,6 +155,7 @@ int main(int argc,char *argv[]) {
   int snd_bms_tot=10, odd_beams=0;
   int snd_freq;
   int snd_frqrng=100;
+  int snd_nrang=75;
   int fast_intt_sc=2;
   int fast_intt_us=500000;
   int snd_intt_sc=1;
@@ -174,7 +177,7 @@ int main(int argc,char *argv[]) {
   mplgs  = 23;
   mpinc  = 1500;
   dmpinc = 1500;
-  nrang  = 100;
+  nrang  = def_nrang;
   rsep   = 45;
   txpl   = 300;     /* note: recomputed below */
   dfrq   = 10200;
@@ -306,6 +309,8 @@ int main(int argc,char *argv[]) {
     exit (1);
   }
 
+  def_nrang = nrang;
+
   if (discretion) cp = -cp;
 
   txpl=(rsep*20)/3;     /* computing TX pulse length */
@@ -320,9 +325,9 @@ int main(int argc,char *argv[]) {
 
   OpsFitACFStart();
 
-  tsgid=SiteTimeSeq(ptab);  /* get the timing sequence */
-
   do {
+
+    tsgid=SiteTimeSeq(ptab);  /* get the timing sequence */
 
     if (SiteStartScan() !=0) continue;
 
@@ -456,6 +461,7 @@ int main(int argc,char *argv[]) {
       while (snd_time-snd_intt > time_needed) {
         intsc = snd_intt_sc;
         intus = snd_intt_us;
+        nrang = snd_nrang;
 
         /* set the beam */
         bmnum = snd_bms[snd_bm_cnt] + odd_beams;
@@ -464,6 +470,7 @@ int main(int argc,char *argv[]) {
         snd_freq = snd_freqs[snd_freq_cnt];
 
         /* the scanning code is here */
+        tsgid = SiteTimeSeq(ptab);
         sprintf(logtxt,"Integrating SND beam:%d intt:%ds.%dus (%d:%d:%d:%d)",bmnum,intsc,intus,hr,mt,sc,us);
         ErrLog(errlog.sock,progname,logtxt);
         ErrLog(errlog.sock,progname,"Setting SND beam.");
@@ -476,7 +483,6 @@ int main(int argc,char *argv[]) {
  *           sprintf(logtxt,"Transmitting SND on: %d (Noise=%g)",tfreq,noise);
  *                     ErrLog(errlog.sock, progname, logtxt);
  *                     */
-        tsgid = SiteTimeSeq(ptab);
         nave = SiteIntegrate(lags);
         if (nave < 0) {
           sprintf(logtxt, "SND integration error: %d", nave);
@@ -559,6 +565,7 @@ int main(int argc,char *argv[]) {
       /* now wait for the next interleavescan */
       intsc = fast_intt_sc;
       intus = fast_intt_us;
+      nrang = def_nrang;
       if (scannowait==0) SiteEndScan(scnsc,scnus,5000);
     }
 

--- a/qnx6/interleavesound.1.0/interleavesound_fh.c
+++ b/qnx6/interleavesound.1.0/interleavesound_fh.c
@@ -538,7 +538,7 @@ int main(int argc,char *argv[]) {
           if (msg.data[n].type==FIT_TYPE) free(msg.ptr[n]);
         }
 
-        sprintf(logtxt, "SBC: %d  SFC: %d\n", snd_bm_cnt, snd_freq_cnt);
+        sprintf(logtxt, "SBC: %d  SFC: %d", snd_bm_cnt, snd_freq_cnt);
         ErrLog(errlog.sock, progname, logtxt);
 
         /* set the scan variable for the sounding mode data file only */
@@ -551,7 +551,7 @@ int main(int argc,char *argv[]) {
         /* save the sounding mode data */
         write_snd_record(progname, prm, fit);
 
-        ErrLog(errlog.sock, progname, "Polling SND for exit.");
+        ErrLog(errlog.sock, progname, "Polling SND for exit.\n");
         if (exitpoll !=0) break;
 
         /* check for the end of a beam loop */

--- a/qnx6/interleavesound.1.0/interleavesound_fh.c
+++ b/qnx6/interleavesound.1.0/interleavesound_fh.c
@@ -161,7 +161,7 @@ int main(int argc,char *argv[]) {
   int snd_freq;
   int snd_frqrng=100;
   int fast_intt_sc=2;
-  int fast_intt_us=500000;
+  int fast_intt_us=400000;
   int snd_intt_sc=1;
   int snd_intt_us=500000;
   float snd_time, snd_intt, time_needed=1.25;

--- a/qnx6/interleavesound.1.0/interleavesound_fh.c
+++ b/qnx6/interleavesound.1.0/interleavesound_fh.c
@@ -128,6 +128,8 @@ int main(int argc,char *argv[]) {
   int status=0;
   int fixfrq=0;
 
+  int def_nrang=100;
+
   /* new variables for dynamically creating beam sequences */
   int *bms;           /* scanning beams                                     */
   int intgt[20];      /* start times of each integration period             */
@@ -160,6 +162,7 @@ int main(int argc,char *argv[]) {
   int snd_bms_tot=10, odd_beams=0;
   int snd_freq;
   int snd_frqrng=100;
+  int snd_nrang=75;
   int fast_intt_sc=2;
   int fast_intt_us=500000;
   int snd_intt_sc=1;
@@ -181,7 +184,7 @@ int main(int argc,char *argv[]) {
   mplgs  = 23;
   mpinc  = 1500;
   dmpinc = 1500;
-  nrang  = 100;
+  nrang  = def_nrang;
   rsep   = 45;
   txpl   = 300;     /* note: recomputed below */
   dfrq   = 10200;
@@ -324,6 +327,8 @@ int main(int argc,char *argv[]) {
     exit (1);
   }
 
+  def_nrang = nrang;
+
   if (discretion) cp = -cp;
 
   txpl=(rsep*20)/3;     /* computing TX pulse length */
@@ -338,9 +343,9 @@ int main(int argc,char *argv[]) {
 
   OpsFitACFStart();
 
-  tsgid=SiteTimeSeq(ptab);  /* get the timing sequence */
-
   do {
+
+    tsgid=SiteTimeSeq(ptab);  /* get the timing sequence */
 
     if (SiteStartScan() !=0) continue;
 
@@ -474,6 +479,7 @@ int main(int argc,char *argv[]) {
       while (snd_time-snd_intt > time_needed) {
         intsc = snd_intt_sc;
         intus = snd_intt_us;
+        nrang = snd_nrang;
 
         /* set the beam */
         bmnum = snd_bms[snd_bm_cnt] + odd_beams;
@@ -482,6 +488,7 @@ int main(int argc,char *argv[]) {
         snd_freq = snd_freqs[snd_freq_cnt];
 
         /* the scanning code is here */
+        tsgid = SiteTimeSeq(ptab);
         sprintf(logtxt,"Integrating SND beam:%d intt:%ds.%dus (%d:%d:%d:%d)",bmnum,intsc,intus,hr,mt,sc,us);
         ErrLog(errlog.sock,progname,logtxt);
         ErrLog(errlog.sock,progname,"Setting SND beam.");
@@ -494,7 +501,6 @@ int main(int argc,char *argv[]) {
  *           sprintf(logtxt,"Transmitting SND on: %d (Noise=%g)",tfreq,noise);
  *                     ErrLog(errlog.sock, progname, logtxt);
  *                     */
-        tsgid = SiteTimeSeq(ptab);
         nave = SiteIntegrate(lags);
         if (nave < 0) {
           sprintf(logtxt, "SND integration error: %d", nave);
@@ -577,6 +583,7 @@ int main(int argc,char *argv[]) {
       /* now wait for the next interleavescan */
       intsc = fast_intt_sc;
       intus = fast_intt_us;
+      nrang = def_nrang;
       if (scannowait==0) SiteEndScan(scnsc,scnus);
     }
 

--- a/qnx6/interleavesound.1.0/interleavesound_fh.c
+++ b/qnx6/interleavesound.1.0/interleavesound_fh.c
@@ -115,8 +115,6 @@ int main(int argc,char *argv[]) {
   char logtxt[1024]="";
   char tempLog[40];
 
-  int exitpoll=0;
-
   int scnsc=60;
   int scnus=0;
 
@@ -440,7 +438,6 @@ int main(int argc,char *argv[]) {
 
       RadarShell(shell.sock,&rstable);
 
-      if (exitpoll !=0 ) break;
       scan = 0;
       if (skip == (nintgs-1)) break;
       skip++;
@@ -449,139 +446,136 @@ int main(int argc,char *argv[]) {
     } while (1);
 
 
-    if (exitpoll==0) {
-      /* In here comes the sounder code */
-      /* set the "sounder mode" scan variable */
-      scan = -2;
+    /* In here comes the sounder code */
+    /* set the "sounder mode" scan variable */
+    scan = -2;
 
-      /* set the xcf variable to do cross-correlations (AOA) */
-      xcf = 1;
+    /* set the xcf variable to do cross-correlations (AOA) */
+    xcf = 1;
 
-      /* set the sounding mode integration time and number of ranges */
-      intsc = snd_intt_sc;
-      intus = snd_intt_us;
-      nrang = snd_nrang;
+    /* set the sounding mode integration time and number of ranges */
+    intsc = snd_intt_sc;
+    intus = snd_intt_us;
+    nrang = snd_nrang;
 
-      /* make a new timing sequence for the sounding */
-      tsgid = SiteTimeSeq(ptab);
+    /* make a new timing sequence for the sounding */
+    tsgid = SiteTimeSeq(ptab);
 
-      /* we have time until the end of the minute to do sounding */
-      /* minus a safety factor given in time_needed */
-      TimeReadClock(&yr,&mo,&dy,&hr,&mt,&sc,&us);
-      snd_time = 60.0 - (sc + us*1e-6);
+    /* we have time until the end of the minute to do sounding */
+    /* minus a safety factor given in time_needed */
+    TimeReadClock(&yr,&mo,&dy,&hr,&mt,&sc,&us);
+    snd_time = 60.0 - (sc + us*1e-6);
 
-      while (snd_time-snd_intt > time_needed) {
+    while (snd_time-snd_intt > time_needed) {
 
-        /* set the beam */
-        bmnum = snd_bms[snd_bm_cnt] + odd_beams;
+      /* set the beam */
+      bmnum = snd_bms[snd_bm_cnt] + odd_beams;
 
-        /* snd_freq will be an array of frequencies to step through */
-        snd_freq = snd_freqs[snd_freq_cnt];
+      /* snd_freq will be an array of frequencies to step through */
+      snd_freq = snd_freqs[snd_freq_cnt];
 
-        /* the scanning code is here */
-        sprintf(logtxt,"Integrating SND beam:%d intt:%ds.%dus (%d:%d:%d:%d)",bmnum,intsc,intus,hr,mt,sc,us);
-        ErrLog(errlog.sock,progname,logtxt);
-        ErrLog(errlog.sock,progname,"Setting SND beam.");
-        SiteStartIntt(intsc,intus);
+      /* the scanning code is here */
+      sprintf(logtxt,"Integrating SND beam:%d intt:%ds.%dus (%d:%d:%d:%d)",bmnum,intsc,intus,hr,mt,sc,us);
+      ErrLog(errlog.sock,progname,logtxt);
+      ErrLog(errlog.sock,progname,"Setting SND beam.");
+      SiteStartIntt(intsc,intus);
 
-        ErrLog(errlog.sock, progname, "Doing SND clear frequency search.");
-        sprintf(logtxt, "FRQ: %d %d", snd_freq, snd_frqrng);
+      ErrLog(errlog.sock, progname, "Doing SND clear frequency search.");
+      sprintf(logtxt, "FRQ: %d %d", snd_freq, snd_frqrng);
+      ErrLog(errlog.sock,progname, logtxt);
+      tfreq = SiteFCLR(snd_freq, snd_freq + snd_frqrng);
+
+      sprintf(logtxt,"Transmitting SND on: %d (Noise=%g)",tfreq,noise);
+      ErrLog(errlog.sock, progname, logtxt);
+
+      nave = SiteIntegrate(lags);
+      if (nave < 0) {
+        sprintf(logtxt, "SND integration error: %d", nave);
         ErrLog(errlog.sock,progname, logtxt);
-        tfreq = SiteFCLR(snd_freq, snd_freq + snd_frqrng);
+        continue;
+      }
+      sprintf(logtxt,"Number of SND sequences: %d",nave);
+      ErrLog(errlog.sock,progname,logtxt);
 
-        sprintf(logtxt,"Transmitting SND on: %d (Noise=%g)",tfreq,noise);
-        ErrLog(errlog.sock, progname, logtxt);
+      OpsBuildPrm(prm,ptab,lags);
+      OpsBuildIQ(iq,&badtr);
+      OpsBuildRaw(raw);
+      FitACF(prm,raw,fblk,fit);
 
-        nave = SiteIntegrate(lags);
-        if (nave < 0) {
-          sprintf(logtxt, "SND integration error: %d", nave);
-          ErrLog(errlog.sock,progname, logtxt);
-          continue;
-        }
-        sprintf(logtxt,"Number of SND sequences: %d",nave);
-        ErrLog(errlog.sock,progname,logtxt);
+      ErrLog(errlog.sock, progname, "Sending SND messages.");
+      msg.num = 0;
+      msg.tsize = 0;
 
-        OpsBuildPrm(prm,ptab,lags);
-        OpsBuildIQ(iq,&badtr);
-        OpsBuildRaw(raw);
-        FitACF(prm,raw,fblk,fit);
+      tmpbuf=RadarParmFlatten(prm,&tmpsze);
+      RMsgSndAdd(&msg,tmpsze,tmpbuf,PRM_TYPE,0);
 
-        ErrLog(errlog.sock, progname, "Sending SND messages.");
-        msg.num = 0;
-        msg.tsize = 0;
+      tmpbuf=IQFlatten(iq,prm->nave,&tmpsze);
+      RMsgSndAdd(&msg,tmpsze,tmpbuf,IQ_TYPE,0);
 
-        tmpbuf=RadarParmFlatten(prm,&tmpsze);
-        RMsgSndAdd(&msg,tmpsze,tmpbuf,PRM_TYPE,0);
+      RMsgSndAdd(&msg,sizeof(unsigned int)*2*iq->tbadtr,
+             (unsigned char *) badtr,BADTR_TYPE,0);
 
-        tmpbuf=IQFlatten(iq,prm->nave,&tmpsze);
-        RMsgSndAdd(&msg,tmpsze,tmpbuf,IQ_TYPE,0);
+      RMsgSndAdd(&msg,strlen(sharedmemory)+1,
+             (unsigned char *) sharedmemory,IQS_TYPE,0);
 
-        RMsgSndAdd(&msg,sizeof(unsigned int)*2*iq->tbadtr,
-               (unsigned char *) badtr,BADTR_TYPE,0);
+      tmpbuf=RawFlatten(raw,prm->nrang,prm->mplgs,&tmpsze);
+      RMsgSndAdd(&msg,tmpsze,tmpbuf,RAW_TYPE,0);
 
-        RMsgSndAdd(&msg,strlen(sharedmemory)+1,
-               (unsigned char *) sharedmemory,IQS_TYPE,0);
+      tmpbuf=FitFlatten(fit,prm->nrang,&tmpsze);
+      RMsgSndAdd(&msg,tmpsze,tmpbuf,FIT_TYPE,0);
 
-        tmpbuf=RawFlatten(raw,prm->nrang,prm->mplgs,&tmpsze);
-        RMsgSndAdd(&msg,tmpsze,tmpbuf,RAW_TYPE,0);
+      RMsgSndAdd(&msg,strlen(progname)+1,(unsigned char *) progname,NME_TYPE,0);
 
-        tmpbuf=FitFlatten(fit,prm->nrang,&tmpsze);
-        RMsgSndAdd(&msg,tmpsze,tmpbuf,FIT_TYPE,0);
-
-        RMsgSndAdd(&msg,strlen(progname)+1,(unsigned char *) progname,NME_TYPE,0);
-
-        RMsgSndSend(task[RT_TASK].sock,&msg);
-        for (n=0;n<msg.num;n++) {
-          if (msg.data[n].type==PRM_TYPE) free(msg.ptr[n]);
-          if (msg.data[n].type==IQ_TYPE) free(msg.ptr[n]);
-          if (msg.data[n].type==RAW_TYPE) free(msg.ptr[n]);
-          if (msg.data[n].type==FIT_TYPE) free(msg.ptr[n]);
-        }
-
-        sprintf(logtxt, "SBC: %d  SFC: %d", snd_bm_cnt, snd_freq_cnt);
-        ErrLog(errlog.sock, progname, logtxt);
-
-        /* set the scan variable for the sounding mode data file only */
-        if ((bmnum == snd_bms[0]) && (snd_freq == snd_freqs[0])) {
-          prm->scan = 1;
-        } else {
-          prm->scan = 0;
-        }
-
-        /* save the sounding mode data */
-        write_snd_record(progname, prm, fit);
-
-        ErrLog(errlog.sock, progname, "Polling SND for exit.\n");
-        if (exitpoll !=0) break;
-
-        /* check for the end of a beam loop */
-        snd_freq_cnt++;
-        if (snd_freq_cnt >= snd_freqs_tot) {
-          /* reset the freq counter and increment the beam counter */
-          snd_freq_cnt = 0;
-          snd_bm_cnt++;
-          if (snd_bm_cnt >= snd_bms_tot) {
-            snd_bm_cnt = 0;
-            odd_beams = !odd_beams;
-          }
-        }
-
-        /* see if we have enough time for another go round */
-        TimeReadClock(&yr, &mo, &dy, &hr, &mt, &sc, &us);
-        snd_time = 60.0 - (sc + us*1e-6);
+      RMsgSndSend(task[RT_TASK].sock,&msg);
+      for (n=0;n<msg.num;n++) {
+        if (msg.data[n].type==PRM_TYPE) free(msg.ptr[n]);
+        if (msg.data[n].type==IQ_TYPE) free(msg.ptr[n]);
+        if (msg.data[n].type==RAW_TYPE) free(msg.ptr[n]);
+        if (msg.data[n].type==FIT_TYPE) free(msg.ptr[n]);
       }
 
-      /* now wait for the next interleavescan */
-      ErrLog(errlog.sock,progname,"Waiting for scan boundary.");
+      sprintf(logtxt, "SBC: %d  SFC: %d", snd_bm_cnt, snd_freq_cnt);
+      ErrLog(errlog.sock, progname, logtxt);
 
-      intsc = fast_intt_sc;
-      intus = fast_intt_us;
-      nrang = def_nrang;
+      /* set the scan variable for the sounding mode data file only */
+      if ((bmnum == snd_bms[0]) && (snd_freq == snd_freqs[0])) {
+        prm->scan = 1;
+      } else {
+        prm->scan = 0;
+      }
 
-      SiteEndScan(scnsc,scnus);
+      /* save the sounding mode data */
+      write_snd_record(progname, prm, fit);
+
+      ErrLog(errlog.sock, progname, "Polling SND for exit.\n");
+
+      /* check for the end of a beam loop */
+      snd_freq_cnt++;
+      if (snd_freq_cnt >= snd_freqs_tot) {
+        /* reset the freq counter and increment the beam counter */
+        snd_freq_cnt = 0;
+        snd_bm_cnt++;
+        if (snd_bm_cnt >= snd_bms_tot) {
+          snd_bm_cnt = 0;
+          odd_beams = !odd_beams;
+        }
+      }
+
+      /* see if we have enough time for another go round */
+      TimeReadClock(&yr, &mo, &dy, &hr, &mt, &sc, &us);
+      snd_time = 60.0 - (sc + us*1e-6);
     }
 
-  } while (exitpoll==0);
+    /* now wait for the next interleavescan */
+    ErrLog(errlog.sock,progname,"Waiting for scan boundary.");
+
+    intsc = fast_intt_sc;
+    intus = fast_intt_us;
+    nrang = def_nrang;
+
+    SiteEndScan(scnsc,scnus);
+
+  } while (1);
 
   for (n=0;n<tnum;n++) RMsgSndClose(task[n].sock);
 

--- a/qnx6/interleavesound.1.0/sndwrite.c
+++ b/qnx6/interleavesound.1.0/sndwrite.c
@@ -109,47 +109,48 @@ int SndWrite(int fid, struct RadarParm *prm, struct FitData *fit) {
   if (prm->xcf !=0) xnum=snum;
   else xnum=0;
 
-  if (snum==0) return 0;
+  if (snum !=0) {
 
-  slist=DataMapStoreArray(ptr,"slist",DATASHORT,1,&snum,NULL);
+    slist=DataMapStoreArray(ptr,"slist",DATASHORT,1,&snum,NULL);
 
-  qflg=DataMapStoreArray(ptr,"qflg",DATACHAR,1,&snum,NULL);
-  gflg=DataMapStoreArray(ptr,"gflg",DATACHAR,1,&snum,NULL);
+    qflg=DataMapStoreArray(ptr,"qflg",DATACHAR,1,&snum,NULL);
+    gflg=DataMapStoreArray(ptr,"gflg",DATACHAR,1,&snum,NULL);
 
-  v=DataMapStoreArray(ptr,"v",DATAFLOAT,1,&snum,NULL);
-  v_e=DataMapStoreArray(ptr,"v_e",DATAFLOAT,1,&snum,NULL);
-  p_l=DataMapStoreArray(ptr,"p_l",DATAFLOAT,1,&snum,NULL);
-  w_l=DataMapStoreArray(ptr,"w_l",DATAFLOAT,1,&snum,NULL);
+    v=DataMapStoreArray(ptr,"v",DATAFLOAT,1,&snum,NULL);
+    v_e=DataMapStoreArray(ptr,"v_e",DATAFLOAT,1,&snum,NULL);
+    p_l=DataMapStoreArray(ptr,"p_l",DATAFLOAT,1,&snum,NULL);
+    w_l=DataMapStoreArray(ptr,"w_l",DATAFLOAT,1,&snum,NULL);
 
-  if (prm->xcf !=0) {
-    x_qflg=DataMapStoreArray(ptr,"x_qflg",DATACHAR,1,&xnum,NULL);
+    if (prm->xcf !=0) {
+      x_qflg=DataMapStoreArray(ptr,"x_qflg",DATACHAR,1,&xnum,NULL);
 
-    phi0=DataMapStoreArray(ptr,"phi0",DATAFLOAT,1,&xnum,NULL);
-    phi0_e=DataMapStoreArray(ptr,"phi0_e",DATAFLOAT,1,&xnum,NULL);
-  }
+      phi0=DataMapStoreArray(ptr,"phi0",DATAFLOAT,1,&xnum,NULL);
+      phi0_e=DataMapStoreArray(ptr,"phi0_e",DATAFLOAT,1,&xnum,NULL);
+    }
 
-  x=0;
+    x=0;
 
-  for (c=0;c<prm->nrang;c++) {
-    if ( (fit->rng[c].qflg==1) ||
-         ((fit->xrng !=NULL) && (fit->xrng[c].qflg==1))) {
-      slist[x]=c;
+    for (c=0;c<prm->nrang;c++) {
+      if ( (fit->rng[c].qflg==1) ||
+           ((fit->xrng !=NULL) && (fit->xrng[c].qflg==1))) {
+        slist[x]=c;
 
-      qflg[x]=fit->rng[c].qflg;
-      gflg[x]=fit->rng[c].gsct;
+        qflg[x]=fit->rng[c].qflg;
+        gflg[x]=fit->rng[c].gsct;
 
-      p_l[x]=fit->rng[c].p_l;
-      v[x]=fit->rng[c].v;
-      v_e[x]=fit->rng[c].v_err;
-      w_l[x]=fit->rng[c].w_l;
+        p_l[x]=fit->rng[c].p_l;
+        v[x]=fit->rng[c].v;
+        v_e[x]=fit->rng[c].v_err;
+        w_l[x]=fit->rng[c].w_l;
 
-      if (xnum !=0) {
-        x_qflg[x]=fit->xrng[c].qflg;
+        if (xnum !=0) {
+          x_qflg[x]=fit->xrng[c].qflg;
 
-        phi0[x]=fit->xrng[c].phi0;
-        phi0_e[x]=fit->xrng[c].phi0_err;
+          phi0[x]=fit->xrng[c].phi0;
+          phi0_e[x]=fit->xrng[c].phi0_err;
+        }
+        x++;
       }
-      x++;
     }
   }
 

--- a/qnx6/normalsound.2.0/normalsound_cv.c
+++ b/qnx6/normalsound.2.0/normalsound_cv.c
@@ -323,7 +323,7 @@ int main(int argc,char *argv[])
   total_scan_usecs = (scnsc-snd_sc)*1E6 + scnus;
   total_integration_usecs = total_scan_usecs/beams;
   def_intt_sc = total_integration_usecs/1E6;
-  def_intt_us = total_integration_usecs - (intsc*1e6);
+  def_intt_us = total_integration_usecs - (def_intt_sc*1e6);
 
   intsc = def_intt_sc;
   intus = def_intt_us;

--- a/qnx6/normalsound.2.0/normalsound_cv.c
+++ b/qnx6/normalsound.2.0/normalsound_cv.c
@@ -200,6 +200,7 @@ int main(int argc,char *argv[])
   OptionAdd(&opt, "di",     'x', &discretion);
   OptionAdd(&opt, "frang",  'i', &frang);
   OptionAdd(&opt, "rsep",   'i', &rsep);
+  OptionAdd(&opt, "nrang",  'i', &nrang);
   OptionAdd(&opt, "dt",     'i', &day);
   OptionAdd(&opt, "nt",     'i', &night);
   OptionAdd(&opt, "df",     'i', &dfrq);
@@ -375,7 +376,7 @@ int main(int argc,char *argv[])
       } else xcf=0;
     } else xcf=0;
 
-    skip=OpsFindSkip(scnsc,scnus);
+    skip=OpsFindSkip(scnsc,scnus,intsc,intus,0);
 
     if (backward) {
       bmnum=sbm-skip;
@@ -606,7 +607,7 @@ int main(int argc,char *argv[])
       /* now wait for the next normalscan */
       intsc = def_intt_sc;
       intus = def_intt_us;
-      if (scannowait==0) SiteEndScan(scnsc,scnus);
+      if (scannowait==0) SiteEndScan(scnsc,scnus,5000);
     }
 
   } while (exitpoll == 0);
@@ -628,6 +629,7 @@ void usage(void)
     printf("    -di     : indicates running during discretionary time\n");
     printf(" -frang int : delay to first range (km) [180]\n");
     printf("  -rsep int : range separation (km) [45]\n");
+    printf(" -nrang int : number of range gates [100]\n");
     printf("    -dt int : hour when day freq. is used [site.c]\n");
     printf("    -nt int : hour when night freq. is used [site.c]\n");
     printf("    -df int : daytime frequency (kHz) [site.c]\n");

--- a/qnx6/normalsound.2.0/normalsound_cv.c
+++ b/qnx6/normalsound.2.0/normalsound_cv.c
@@ -463,10 +463,6 @@ int main(int argc,char *argv[])
       for (n=0;n<tnum;n++) RMsgSndSend(task[n].sock,&msg);
 
       for (n=0; n<msg.num; n++) {
-        //if (msg.data[n].type == PRM_TYPE) free(msg.ptr[n]);
-        //if (msg.data[n].type == IQ_TYPE) free(msg.ptr[n]);
-        //if (msg.data[n].type == RAW_TYPE) free(msg.ptr[n]);
-        //if (msg.data[n].type == FIT_TYPE) free(msg.ptr[n]);
         if ( (msg.data[n].type == PRM_TYPE) ||
              (msg.data[n].type == IQ_TYPE)  ||
              (msg.data[n].type == RAW_TYPE) ||

--- a/qnx6/normalsound.2.0/normalsound_cv.c
+++ b/qnx6/normalsound.2.0/normalsound_cv.c
@@ -141,19 +141,19 @@ int main(int argc,char *argv[])
   unsigned char hlp=0;
 
   if (debug) {
-    printf("Size of int %ld\n",sizeof(int));
-    printf("Size of long %ld\n",sizeof(long));
-    printf("Size of long long %ld\n",sizeof(long long));
-    printf("Size of struct TRTimes %ld\n",sizeof(struct TRTimes));
-    printf("Size of struct SeqPRM %ld\n",sizeof(struct SeqPRM));
-    printf("Size of struct RosData %ld\n",sizeof(struct RosData));
-    printf("Size of struct DataPRM %ld\n",sizeof(struct DataPRM));
-    printf("Size of Struct ControlPRM  %ld\n",sizeof(struct ControlPRM));
-    printf("Size of Struct RadarPRM  %ld\n",sizeof(struct RadarPRM));
-    printf("Size of Struct ROSMsg  %ld\n",sizeof(struct ROSMsg));
-    printf("Size of Struct CLRFreq  %ld\n",sizeof(struct CLRFreqPRM));
-    printf("Size of Struct TSGprm  %ld\n",sizeof(struct TSGprm));
-    printf("Size of Struct SiteSettings  %ld\n",sizeof(struct SiteSettings));
+    printf("Size of int %u\n",sizeof(int));
+    printf("Size of long %u\n",sizeof(long));
+    printf("Size of long long %u\n",sizeof(long long));
+    printf("Size of struct TRTimes %u\n",sizeof(struct TRTimes));
+    printf("Size of struct SeqPRM %u\n",sizeof(struct SeqPRM));
+    printf("Size of struct RosData %u\n",sizeof(struct RosData));
+    printf("Size of struct DataPRM %u\n",sizeof(struct DataPRM));
+    printf("Size of Struct ControlPRM  %u\n",sizeof(struct ControlPRM));
+    printf("Size of Struct RadarPRM  %u\n",sizeof(struct RadarPRM));
+    printf("Size of Struct ROSMsg  %u\n",sizeof(struct ROSMsg));
+    printf("Size of Struct CLRFreq  %u\n",sizeof(struct CLRFreqPRM));
+    printf("Size of Struct TSGprm  %u\n",sizeof(struct TSGprm));
+    printf("Size of Struct SiteSettings  %u\n",sizeof(struct SiteSettings));
   }
 
 
@@ -353,8 +353,6 @@ int main(int argc,char *argv[])
   printf("Entering Scan loop Station ID: %s  %d\n",ststr,stid);
   do {
 
-//    if (timed) gettimeofday(&t0,NULL);
-
     printf("Preparing SiteTimeSeq Station ID: %s  %d\n",ststr,stid);
     tsgid=SiteTimeSeq(ptab);
 
@@ -392,8 +390,6 @@ int main(int argc,char *argv[])
 
     do {
 
-//      if (timed) gettimeofday(&t1,NULL);
-
       TimeReadClock(&yr,&mo,&dy,&hr,&mt,&sc,&us);
 
       if (OpsDayNight()==1) {
@@ -425,7 +421,6 @@ int main(int argc,char *argv[])
       sprintf(logtxt,"Transmitting on: %d (Noise=%g)",tfreq,noise);
       ErrLog(errlog.sock,progname,logtxt);
 
-//      if (timed) gettimeofday(&t2,NULL);
       nave=SiteIntegrate(lags);
       if (nave < 0) {
         sprintf(logtxt,"Integration error:%d",nave);

--- a/qnx6/normalsound.2.0/normalsound_cv.c
+++ b/qnx6/normalsound.2.0/normalsound_cv.c
@@ -570,7 +570,7 @@ int main(int argc,char *argv[])
           if (msg.data[n].type==FIT_TYPE) free(msg.ptr[n]);
         }
 
-        sprintf(logtxt, "SBC: %d  SFC: %d\n", snd_bm_cnt, snd_freq_cnt);
+        sprintf(logtxt, "SBC: %d  SFC: %d", snd_bm_cnt, snd_freq_cnt);
         ErrLog(errlog.sock, progname, logtxt);
 
         /* set the scan variable for the sounding mode data file only */
@@ -583,7 +583,7 @@ int main(int argc,char *argv[])
         /* save the sounding mode data */
         write_snd_record(progname, prm, fit);
 
-        ErrLog(errlog.sock, progname, "Polling SND for exit.");
+        ErrLog(errlog.sock, progname, "Polling SND for exit.\n");
         if (exitpoll !=0) break;
 
         /* check for the end of a beam loop */

--- a/qnx6/normalsound.2.0/normalsound_cv.c
+++ b/qnx6/normalsound.2.0/normalsound_cv.c
@@ -135,6 +135,7 @@ int main(int argc,char *argv[])
   int total_integration_usecs=0;
   int def_intt_sc=0;
   int def_intt_us=0;
+  int def_nrang=0;
   int debug=0;
 
   unsigned char hlp=0;
@@ -170,6 +171,7 @@ int main(int argc,char *argv[])
   int snd_bms_tot=10, odd_beams=0;
   int snd_freq;
   int snd_frqrng=100;
+  int snd_nrang=75;
   int snd_sc=12;
   int snd_intt_sc=1;
   int snd_intt_us=500000;
@@ -325,6 +327,8 @@ int main(int argc,char *argv[])
   def_intt_sc = total_integration_usecs/1E6;
   def_intt_us = total_integration_usecs - (intsc*1e6);
 
+  def_nrang = nrang;
+
   intsc = def_intt_sc;
   intus = def_intt_us;
 
@@ -346,13 +350,13 @@ int main(int argc,char *argv[])
   printf("Preparing OpsFitACFStart Station ID: %s  %d\n",ststr,stid);
   OpsFitACFStart();
 
-  printf("Preparing SiteTimeSeq Station ID: %s  %d\n",ststr,stid);
-  tsgid=SiteTimeSeq(ptab);
-
   printf("Entering Scan loop Station ID: %s  %d\n",ststr,stid);
   do {
 
 //    if (timed) gettimeofday(&t0,NULL);
+
+    printf("Preparing SiteTimeSeq Station ID: %s  %d\n",ststr,stid);
+    tsgid=SiteTimeSeq(ptab);
 
     printf("Entering Site Start Scan Station ID: %s  %d\n",ststr,stid);
     if (SiteStartScan() !=0) continue;
@@ -504,6 +508,7 @@ int main(int argc,char *argv[])
       while (snd_time-snd_intt > time_needed) {
         intsc = snd_intt_sc;
         intus = snd_intt_us;
+        nrang = snd_nrang;
 
         /* set the beam */
         bmnum = snd_bms[snd_bm_cnt] + odd_beams;
@@ -512,6 +517,7 @@ int main(int argc,char *argv[])
         snd_freq = snd_freqs[snd_freq_cnt];
 
         /* the scanning code is here */
+        tsgid = SiteTimeSeq(ptab);
         sprintf(logtxt,"Integrating SND beam:%d intt:%ds.%dus (%d:%d:%d:%d)",bmnum,intsc,intus,hr,mt,sc,us);
         ErrLog(errlog.sock,progname,logtxt);
         ErrLog(errlog.sock,progname,"Setting SND beam.");
@@ -524,7 +530,6 @@ int main(int argc,char *argv[])
  *           sprintf(logtxt,"Transmitting SND on: %d (Noise=%g)",tfreq,noise);
  *                     ErrLog(errlog.sock, progname, logtxt);
  *                     */
-        tsgid = SiteTimeSeq(ptab);
         nave = SiteIntegrate(lags);
         if (nave < 0) {
           sprintf(logtxt, "SND integration error: %d", nave);
@@ -607,6 +612,7 @@ int main(int argc,char *argv[])
       /* now wait for the next normalscan */
       intsc = def_intt_sc;
       intus = def_intt_us;
+      nrang = def_nrang;
       if (scannowait==0) SiteEndScan(scnsc,scnus,5000);
     }
 

--- a/qnx6/normalsound.2.0/normalsound_fh.c
+++ b/qnx6/normalsound.2.0/normalsound_fh.c
@@ -138,6 +138,7 @@ int main(int argc,char *argv[])
   int total_integration_usecs=0;
   int def_intt_sc=0;
   int def_intt_us=0;
+  int def_nrang=0;
   int debug=0;
 
   unsigned char hlp=0;
@@ -173,6 +174,7 @@ int main(int argc,char *argv[])
   int snd_bms_tot=10, odd_beams=0;
   int snd_freq;
   int snd_frqrng=100;
+  int snd_nrang=75;
   int snd_sc=12;
   int snd_intt_sc=1;
   int snd_intt_us=500000;
@@ -336,6 +338,8 @@ int main(int argc,char *argv[])
   def_intt_sc = total_integration_usecs/1E6;
   def_intt_us = total_integration_usecs - (intsc*1e6);
 
+  def_nrang = nrang;
+
   intsc = def_intt_sc;
   intus = def_intt_us;
 
@@ -357,13 +361,13 @@ int main(int argc,char *argv[])
   printf("Preparing OpsFitACFStart Station ID: %s  %d\n",ststr,stid);
   OpsFitACFStart();
 
-  printf("Preparing SiteTimeSeq Station ID: %s  %d\n",ststr,stid);
-  tsgid=SiteTimeSeq(ptab);
-
   printf("Entering Scan loop Station ID: %s  %d\n",ststr,stid);
   do {
 
 //    if (timed) gettimeofday(&t0,NULL);
+
+    printf("Preparing SiteTimeSeq Station ID: %s  %d\n",ststr,stid);
+    tsgid=SiteTimeSeq(ptab);
 
     printf("Entering Site Start Scan Station ID: %s  %d\n",ststr,stid);
     if (SiteStartScan() !=0) continue;
@@ -515,6 +519,7 @@ int main(int argc,char *argv[])
       while (snd_time-snd_intt > time_needed) {
         intsc = snd_intt_sc;
         intus = snd_intt_us;
+        nrang = snd_nrang;
 
         /* set the beam */
         bmnum = snd_bms[snd_bm_cnt] + odd_beams;
@@ -523,6 +528,7 @@ int main(int argc,char *argv[])
         snd_freq = snd_freqs[snd_freq_cnt];
 
         /* the scanning code is here */
+        tsgid = SiteTimeSeq(ptab);
         sprintf(logtxt,"Integrating SND beam:%d intt:%ds.%dus (%d:%d:%d:%d)",bmnum,intsc,intus,hr,mt,sc,us);
         ErrLog(errlog.sock,progname,logtxt);
         ErrLog(errlog.sock,progname,"Setting SND beam.");
@@ -535,7 +541,6 @@ int main(int argc,char *argv[])
  *           sprintf(logtxt,"Transmitting SND on: %d (Noise=%g)",tfreq,noise);
  *                     ErrLog(errlog.sock, progname, logtxt);
  *                     */
-        tsgid = SiteTimeSeq(ptab);
         nave = SiteIntegrate(lags);
         if (nave < 0) {
           sprintf(logtxt, "SND integration error: %d", nave);
@@ -618,6 +623,7 @@ int main(int argc,char *argv[])
       /* now wait for the next normalscan */
       intsc = def_intt_sc;
       intus = def_intt_us;
+      nrang = def_nrang;
       if (scannowait==0) SiteEndScan(scnsc,scnus);
     }
 

--- a/qnx6/normalsound.2.0/normalsound_fh.c
+++ b/qnx6/normalsound.2.0/normalsound_fh.c
@@ -118,8 +118,6 @@ int main(int argc,char *argv[])
 
   char logtxt[1024];
 
-  int exitpoll=0;
- 
   int scnsc=120;    /* total scan period in seconds */
   int scnus=0;
   int skip;
@@ -480,8 +478,6 @@ int main(int argc,char *argv[])
 
       RadarShell(shell.sock,&rstable);
 
-      if (exitpoll != 0) break;
-
       scan = 0;
       if (bmnum == ebm) break;
 
@@ -491,139 +487,136 @@ int main(int argc,char *argv[])
     } while (1);
 
 
-    if (exitpoll==0) {
-      /* In here comes the sounder code */
-      /* set the "sounder mode" scan variable */
-      scan = -2;
+    /* In here comes the sounder code */
+    /* set the "sounder mode" scan variable */
+    scan = -2;
 
-      /* set the xcf variable to do cross-correlations (AOA) */
-      xcf = 1;
+    /* set the xcf variable to do cross-correlations (AOA) */
+    xcf = 1;
 
-      /* set the sounding mode integration time and number of ranges */
-      intsc = snd_intt_sc;
-      intus = snd_intt_us;
-      nrang = snd_nrang;
+    /* set the sounding mode integration time and number of ranges */
+    intsc = snd_intt_sc;
+    intus = snd_intt_us;
+    nrang = snd_nrang;
 
-      /* make a new timing sequence for the sounding */
-      tsgid = SiteTimeSeq(ptab);
+    /* make a new timing sequence for the sounding */
+    tsgid = SiteTimeSeq(ptab);
 
-      /* we have time until the end of the minute to do sounding */
-      /* minus a safety factor given in time_needed */
-      TimeReadClock(&yr,&mo,&dy,&hr,&mt,&sc,&us);
-      snd_time = 60.0 - (sc + us*1e-6);
+    /* we have time until the end of the minute to do sounding */
+    /* minus a safety factor given in time_needed */
+    TimeReadClock(&yr,&mo,&dy,&hr,&mt,&sc,&us);
+    snd_time = 60.0 - (sc + us*1e-6);
 
-      while (snd_time-snd_intt > time_needed) {
+    while (snd_time-snd_intt > time_needed) {
 
-        /* set the beam */
-        bmnum = snd_bms[snd_bm_cnt] + odd_beams;
+      /* set the beam */
+      bmnum = snd_bms[snd_bm_cnt] + odd_beams;
 
-        /* snd_freq will be an array of frequencies to step through */
-        snd_freq = snd_freqs[snd_freq_cnt];
+      /* snd_freq will be an array of frequencies to step through */
+      snd_freq = snd_freqs[snd_freq_cnt];
 
-        /* the scanning code is here */
-        sprintf(logtxt,"Integrating SND beam:%d intt:%ds.%dus (%d:%d:%d:%d)",bmnum,intsc,intus,hr,mt,sc,us);
-        ErrLog(errlog.sock,progname,logtxt);
-        ErrLog(errlog.sock,progname,"Setting SND beam.");
-        SiteStartIntt(intsc,intus);
+      /* the scanning code is here */
+      sprintf(logtxt,"Integrating SND beam:%d intt:%ds.%dus (%d:%d:%d:%d)",bmnum,intsc,intus,hr,mt,sc,us);
+      ErrLog(errlog.sock,progname,logtxt);
+      ErrLog(errlog.sock,progname,"Setting SND beam.");
+      SiteStartIntt(intsc,intus);
 
-        ErrLog(errlog.sock, progname, "Doing SND clear frequency search.");
-        sprintf(logtxt, "FRQ: %d %d", snd_freq, snd_frqrng);
+      ErrLog(errlog.sock, progname, "Doing SND clear frequency search.");
+      sprintf(logtxt, "FRQ: %d %d", snd_freq, snd_frqrng);
+      ErrLog(errlog.sock,progname, logtxt);
+      tfreq = SiteFCLR(snd_freq, snd_freq + snd_frqrng);
+
+      sprintf(logtxt,"Transmitting SND on: %d (Noise=%g)",tfreq,noise);
+      ErrLog(errlog.sock, progname, logtxt);
+
+      nave = SiteIntegrate(lags);
+      if (nave < 0) {
+        sprintf(logtxt, "SND integration error: %d", nave);
         ErrLog(errlog.sock,progname, logtxt);
-        tfreq = SiteFCLR(snd_freq, snd_freq + snd_frqrng);
+        continue;
+      }
+      sprintf(logtxt,"Number of SND sequences: %d",nave);
+      ErrLog(errlog.sock,progname,logtxt);
 
-        sprintf(logtxt,"Transmitting SND on: %d (Noise=%g)",tfreq,noise);
-        ErrLog(errlog.sock, progname, logtxt);
+      OpsBuildPrm(prm,ptab,lags);
+      OpsBuildIQ(iq,&badtr);
+      OpsBuildRaw(raw);
+      FitACF(prm,raw,fblk,fit);
 
-        nave = SiteIntegrate(lags);
-        if (nave < 0) {
-          sprintf(logtxt, "SND integration error: %d", nave);
-          ErrLog(errlog.sock,progname, logtxt);
-          continue;
-        }
-        sprintf(logtxt,"Number of SND sequences: %d",nave);
-        ErrLog(errlog.sock,progname,logtxt);
+      ErrLog(errlog.sock, progname, "Sending SND messages.");
+      msg.num = 0;
+      msg.tsize = 0;
 
-        OpsBuildPrm(prm,ptab,lags);
-        OpsBuildIQ(iq,&badtr);
-        OpsBuildRaw(raw);
-        FitACF(prm,raw,fblk,fit);
+      tmpbuf=RadarParmFlatten(prm,&tmpsze);
+      RMsgSndAdd(&msg,tmpsze,tmpbuf,PRM_TYPE,0);
 
-        ErrLog(errlog.sock, progname, "Sending SND messages.");
-        msg.num = 0;
-        msg.tsize = 0;
+      tmpbuf=IQFlatten(iq,prm->nave,&tmpsze);
+      RMsgSndAdd(&msg,tmpsze,tmpbuf,IQ_TYPE,0);
 
-        tmpbuf=RadarParmFlatten(prm,&tmpsze);
-        RMsgSndAdd(&msg,tmpsze,tmpbuf,PRM_TYPE,0);
+      RMsgSndAdd(&msg,sizeof(unsigned int)*2*iq->tbadtr,
+             (unsigned char *) badtr,BADTR_TYPE,0);
 
-        tmpbuf=IQFlatten(iq,prm->nave,&tmpsze);
-        RMsgSndAdd(&msg,tmpsze,tmpbuf,IQ_TYPE,0);
+      RMsgSndAdd(&msg,strlen(sharedmemory)+1,
+             (unsigned char *) sharedmemory,IQS_TYPE,0);
 
-        RMsgSndAdd(&msg,sizeof(unsigned int)*2*iq->tbadtr,
-               (unsigned char *) badtr,BADTR_TYPE,0);
+      tmpbuf=RawFlatten(raw,prm->nrang,prm->mplgs,&tmpsze);
+      RMsgSndAdd(&msg,tmpsze,tmpbuf,RAW_TYPE,0);
 
-        RMsgSndAdd(&msg,strlen(sharedmemory)+1,
-               (unsigned char *) sharedmemory,IQS_TYPE,0);
+      tmpbuf=FitFlatten(fit,prm->nrang,&tmpsze);
+      RMsgSndAdd(&msg,tmpsze,tmpbuf,FIT_TYPE,0);
 
-        tmpbuf=RawFlatten(raw,prm->nrang,prm->mplgs,&tmpsze);
-        RMsgSndAdd(&msg,tmpsze,tmpbuf,RAW_TYPE,0);
+      RMsgSndAdd(&msg,strlen(progname)+1,(unsigned char *) progname,NME_TYPE,0);
 
-        tmpbuf=FitFlatten(fit,prm->nrang,&tmpsze);
-        RMsgSndAdd(&msg,tmpsze,tmpbuf,FIT_TYPE,0);
-
-        RMsgSndAdd(&msg,strlen(progname)+1,(unsigned char *) progname,NME_TYPE,0);
-
-        RMsgSndSend(task[RT_TASK].sock,&msg);
-        for (n=0;n<msg.num;n++) {
-          if (msg.data[n].type==PRM_TYPE) free(msg.ptr[n]);
-          if (msg.data[n].type==IQ_TYPE) free(msg.ptr[n]);
-          if (msg.data[n].type==RAW_TYPE) free(msg.ptr[n]);
-          if (msg.data[n].type==FIT_TYPE) free(msg.ptr[n]);
-        }
-
-        sprintf(logtxt, "SBC: %d  SFC: %d", snd_bm_cnt, snd_freq_cnt);
-        ErrLog(errlog.sock, progname, logtxt);
-
-        /* set the scan variable for the sounding mode data file only */
-        if ((bmnum == snd_bms[0]) && (snd_freq == snd_freqs[0])) {
-          prm->scan = 1;
-        } else {
-          prm->scan = 0;
-        }
-
-        /* save the sounding mode data */
-        write_snd_record(progname, prm, fit);
-
-        ErrLog(errlog.sock, progname, "Polling SND for exit.\n");
-        if (exitpoll !=0) break;
-
-        /* check for the end of a beam loop */
-        snd_freq_cnt++;
-        if (snd_freq_cnt >= snd_freqs_tot) {
-          /* reset the freq counter and increment the beam counter */
-          snd_freq_cnt = 0;
-          snd_bm_cnt++;
-          if (snd_bm_cnt >= snd_bms_tot) {
-            snd_bm_cnt = 0;
-            odd_beams = !odd_beams;
-          }
-        }
-
-        /* see if we have enough time for another go round */
-        TimeReadClock(&yr, &mo, &dy, &hr, &mt, &sc, &us);
-        snd_time = 60.0 - (sc + us*1e-6);
+      RMsgSndSend(task[RT_TASK].sock,&msg);
+      for (n=0;n<msg.num;n++) {
+        if (msg.data[n].type==PRM_TYPE) free(msg.ptr[n]);
+        if (msg.data[n].type==IQ_TYPE) free(msg.ptr[n]);
+        if (msg.data[n].type==RAW_TYPE) free(msg.ptr[n]);
+        if (msg.data[n].type==FIT_TYPE) free(msg.ptr[n]);
       }
 
-      /* now wait for the next normalscan */
-      ErrLog(errlog.sock,progname,"Waiting for scan boundary.");
+      sprintf(logtxt, "SBC: %d  SFC: %d", snd_bm_cnt, snd_freq_cnt);
+      ErrLog(errlog.sock, progname, logtxt);
 
-      intsc = def_intt_sc;
-      intus = def_intt_us;
-      nrang = def_nrang;
+      /* set the scan variable for the sounding mode data file only */
+      if ((bmnum == snd_bms[0]) && (snd_freq == snd_freqs[0])) {
+        prm->scan = 1;
+      } else {
+        prm->scan = 0;
+      }
 
-      SiteEndScan(scnsc,scnus);
+      /* save the sounding mode data */
+      write_snd_record(progname, prm, fit);
+
+      ErrLog(errlog.sock, progname, "Polling SND for exit.\n");
+
+      /* check for the end of a beam loop */
+      snd_freq_cnt++;
+      if (snd_freq_cnt >= snd_freqs_tot) {
+        /* reset the freq counter and increment the beam counter */
+        snd_freq_cnt = 0;
+        snd_bm_cnt++;
+        if (snd_bm_cnt >= snd_bms_tot) {
+          snd_bm_cnt = 0;
+          odd_beams = !odd_beams;
+        }
+      }
+
+      /* see if we have enough time for another go round */
+      TimeReadClock(&yr, &mo, &dy, &hr, &mt, &sc, &us);
+      snd_time = 60.0 - (sc + us*1e-6);
     }
 
-  } while (exitpoll == 0);
+    /* now wait for the next normalscan */
+    ErrLog(errlog.sock,progname,"Waiting for scan boundary.");
+
+    intsc = def_intt_sc;
+    intus = def_intt_us;
+    nrang = def_nrang;
+
+    SiteEndScan(scnsc,scnus);
+
+  } while (1);
 
   for (n=0; n<tnum; n++) RMsgSndClose(task[n].sock);
 

--- a/qnx6/normalsound.2.0/normalsound_fh.c
+++ b/qnx6/normalsound.2.0/normalsound_fh.c
@@ -334,7 +334,7 @@ int main(int argc,char *argv[])
   total_scan_usecs = (scnsc-snd_sc)*1E6 + scnus;
   total_integration_usecs = total_scan_usecs/beams;
   def_intt_sc = total_integration_usecs/1E6;
-  def_intt_us = total_integration_usecs - (intsc*1e6);
+  def_intt_us = total_integration_usecs - (def_intt_sc*1e6);
 
   intsc = def_intt_sc;
   intus = def_intt_us;

--- a/qnx6/normalsound.2.0/normalsound_fh.c
+++ b/qnx6/normalsound.2.0/normalsound_fh.c
@@ -580,7 +580,7 @@ int main(int argc,char *argv[])
           if (msg.data[n].type==FIT_TYPE) free(msg.ptr[n]);
         }
 
-        sprintf(logtxt, "SBC: %d  SFC: %d\n", snd_bm_cnt, snd_freq_cnt);
+        sprintf(logtxt, "SBC: %d  SFC: %d", snd_bm_cnt, snd_freq_cnt);
         ErrLog(errlog.sock, progname, logtxt);
 
         /* set the scan variable for the sounding mode data file only */
@@ -593,7 +593,7 @@ int main(int argc,char *argv[])
         /* save the sounding mode data */
         write_snd_record(progname, prm, fit);
 
-        ErrLog(errlog.sock, progname, "Polling SND for exit.");
+        ErrLog(errlog.sock, progname, "Polling SND for exit.\n");
         if (exitpoll !=0) break;
 
         /* check for the end of a beam loop */

--- a/qnx6/normalsound.2.0/sndwrite.c
+++ b/qnx6/normalsound.2.0/sndwrite.c
@@ -109,47 +109,48 @@ int SndWrite(int fid, struct RadarParm *prm, struct FitData *fit) {
   if (prm->xcf !=0) xnum=snum;
   else xnum=0;
 
-  if (snum==0) return 0;
+  if (snum !=0) {
 
-  slist=DataMapStoreArray(ptr,"slist",DATASHORT,1,&snum,NULL);
+    slist=DataMapStoreArray(ptr,"slist",DATASHORT,1,&snum,NULL);
 
-  qflg=DataMapStoreArray(ptr,"qflg",DATACHAR,1,&snum,NULL);
-  gflg=DataMapStoreArray(ptr,"gflg",DATACHAR,1,&snum,NULL);
+    qflg=DataMapStoreArray(ptr,"qflg",DATACHAR,1,&snum,NULL);
+    gflg=DataMapStoreArray(ptr,"gflg",DATACHAR,1,&snum,NULL);
 
-  v=DataMapStoreArray(ptr,"v",DATAFLOAT,1,&snum,NULL);
-  v_e=DataMapStoreArray(ptr,"v_e",DATAFLOAT,1,&snum,NULL);
-  p_l=DataMapStoreArray(ptr,"p_l",DATAFLOAT,1,&snum,NULL);
-  w_l=DataMapStoreArray(ptr,"w_l",DATAFLOAT,1,&snum,NULL);
+    v=DataMapStoreArray(ptr,"v",DATAFLOAT,1,&snum,NULL);
+    v_e=DataMapStoreArray(ptr,"v_e",DATAFLOAT,1,&snum,NULL);
+    p_l=DataMapStoreArray(ptr,"p_l",DATAFLOAT,1,&snum,NULL);
+    w_l=DataMapStoreArray(ptr,"w_l",DATAFLOAT,1,&snum,NULL);
 
-  if (prm->xcf !=0) {
-    x_qflg=DataMapStoreArray(ptr,"x_qflg",DATACHAR,1,&xnum,NULL);
+    if (prm->xcf !=0) {
+      x_qflg=DataMapStoreArray(ptr,"x_qflg",DATACHAR,1,&xnum,NULL);
 
-    phi0=DataMapStoreArray(ptr,"phi0",DATAFLOAT,1,&xnum,NULL);
-    phi0_e=DataMapStoreArray(ptr,"phi0_e",DATAFLOAT,1,&xnum,NULL);
-  }
+      phi0=DataMapStoreArray(ptr,"phi0",DATAFLOAT,1,&xnum,NULL);
+      phi0_e=DataMapStoreArray(ptr,"phi0_e",DATAFLOAT,1,&xnum,NULL);
+    }
 
-  x=0;
+    x=0;
 
-  for (c=0;c<prm->nrang;c++) {
-    if ( (fit->rng[c].qflg==1) ||
-         ((fit->xrng !=NULL) && (fit->xrng[c].qflg==1))) {
-      slist[x]=c;
+    for (c=0;c<prm->nrang;c++) {
+      if ( (fit->rng[c].qflg==1) ||
+           ((fit->xrng !=NULL) && (fit->xrng[c].qflg==1))) {
+        slist[x]=c;
 
-      qflg[x]=fit->rng[c].qflg;
-      gflg[x]=fit->rng[c].gsct;
+        qflg[x]=fit->rng[c].qflg;
+        gflg[x]=fit->rng[c].gsct;
 
-      p_l[x]=fit->rng[c].p_l;
-      v[x]=fit->rng[c].v;
-      v_e[x]=fit->rng[c].v_err;
-      w_l[x]=fit->rng[c].w_l;
+        p_l[x]=fit->rng[c].p_l;
+        v[x]=fit->rng[c].v;
+        v_e[x]=fit->rng[c].v_err;
+        w_l[x]=fit->rng[c].w_l;
 
-      if (xnum !=0) {
-        x_qflg[x]=fit->xrng[c].qflg;
+        if (xnum !=0) {
+          x_qflg[x]=fit->xrng[c].qflg;
 
-        phi0[x]=fit->xrng[c].phi0;
-        phi0_e[x]=fit->xrng[c].phi0_err;
+          phi0[x]=fit->xrng[c].phi0;
+          phi0_e[x]=fit->xrng[c].phi0_err;
+        }
+        x++;
       }
-      x++;
     }
   }
 

--- a/ros.1.02/interleavesound.1.00/interleavesound.c
+++ b/ros.1.02/interleavesound.1.00/interleavesound.c
@@ -418,12 +418,16 @@ void main(int argc,char *argv[]) {
       }
     } while (1);
 
+
     if (exit_poll==0) {
       /* set the "sounder mode" scan variable */
       scan=-2;
 
       /* set the xcf variable to do cross-correlations (AOA) */
       xcf=1;
+
+      /* set the sounding mode integration time and number of ranges */
+      intt = snd_intt;
 
       /* setup the sounder mode integration time */
       /* determine the number of seconds we have for this mode  */
@@ -433,7 +437,6 @@ void main(int argc,char *argv[]) {
       snd_time = 60.0 - (sec+msec/1000.);
 
       while(snd_time-(float)snd_intt > time_needed) {
-        intt = snd_intt;
 
         /* set the beam */
         bmnum = snd_bms[snd_bm_cnt] + odd_beams;


### PR DESCRIPTION
This pull request merges the upstream interleavesound (and normalsound) changes from the `superdarn/control_programs` repository into the `gbr-operations` branch of the `vtsuperdarn/control_programs` repository. All of the site-specific information already on the `gbr-interleavesound_range-update` branch should still be intact (ie the use of `interleave_sounder.dat` rather than a more generic `sounder_[rad].dat` file).